### PR TITLE
Finished multi-lang implementation (all on the frontend)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,1 +1,53 @@
-{"options":{"allowedHosts":["localhost",".localhost"],"proxy":"https://localhost:8080/api"},"name":"frontend","version":"0.1.0","private":true,"scripts":{"dev":"next dev","build":"next build","start":"next start","lint":"next lint"},"dependencies":{"@emotion/react":"^11.13.3","@emotion/styled":"^11.13.0","@mui/icons-material":"^6.1.3","@mui/material":"^6.1.4","@types/proj4":"^2.5.5","d3":"^7.9.0","d3-hexbin":"^0.2.2","deck.gl":"^9.0.34","leaflet":"^1.9.4","maplibre-gl":"^4.7.1","next":"15.0.2","proj4":"^2.14.0","react":"^18","react-dom":"^18","react-leaflet":"^4.2.1","react-map-gl":"^7.1.7"},"devDependencies":{"@types/d3":"^7.4.3","@types/d3-hexbin":"^0.2.5","@types/leaflet":"^1.9.14","@types/node":"^22","@types/react":"^18","@types/react-dom":"^18","eslint":"^8.57.1","eslint-config-next":"15.0.2","postcss":"^8","tailwindcss":"^3.4.14","typescript":"^5"},"packageManager":"yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"}
+{
+  "options": {
+    "allowedHosts": [
+      "localhost",
+      ".localhost"
+    ],
+    "proxy": "https://localhost:8080/api"
+  },
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.13.0",
+    "@mui/icons-material": "^6.1.3",
+    "@mui/material": "^6.1.4",
+    "@types/proj4": "^2.5.5",
+    "d3": "^7.9.0",
+    "d3-hexbin": "^0.2.2",
+    "deck.gl": "^9.0.34",
+    "i18next": "^23.16.5",
+    "i18next-http-backend": "^2.6.2",
+    "leaflet": "^1.9.4",
+    "maplibre-gl": "^4.7.1",
+    "next": "15.0.2",
+    "proj4": "^2.14.0",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-i18next": "^15.1.1",
+    "react-leaflet": "^4.2.1",
+    "react-map-gl": "^7.1.7"
+  },
+  "devDependencies": {
+    "@types/d3": "^7.4.3",
+    "@types/d3-hexbin": "^0.2.5",
+    "@types/leaflet": "^1.9.14",
+    "@types/node": "^22",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "15.0.2",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+}

--- a/frontend/src/components/multi-Lang/LangSwitch.tsx
+++ b/frontend/src/components/multi-Lang/LangSwitch.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Switch, FormControlLabel } from "@mui/material";
+
+const LangChange: React.FC = () => {
+  const [currentLanguage, setCurrentLanguage] = useState<string>("en");
+  const { i18n } = useTranslation();
+
+  // Function to change the language
+  const changeLanguage = (lang: string) => {
+    i18n.changeLanguage(lang); // Change the language in i18n
+    setCurrentLanguage(lang); // Update the current language in state
+    localStorage.setItem("language", lang); // Persist the selected language in localStorage
+  };
+
+  // Effect to load the language from localStorage when the component mounts
+  useEffect(() => {
+    const savedLanguage = localStorage.getItem("language");
+    if (savedLanguage) {
+      setCurrentLanguage(savedLanguage); // Set the language to the saved value if available
+    } else {
+      localStorage.setItem("language", currentLanguage); // Initialize language in localStorage if not set
+    }
+  }, [currentLanguage]);
+
+  // Effect to apply the current language to i18n whenever the language state changes
+  useEffect(() => {
+    i18n.changeLanguage(currentLanguage); // Change the language in i18n whenever the state changes
+  }, [currentLanguage, i18n]);
+
+  return (
+    <div>
+      {/* Use a toggle switch to switch between English and Spanish */}
+      <FormControlLabel
+        control={
+          <Switch
+            checked={currentLanguage === "mong"} // Spanish is true, otherwise English
+            onChange={() =>
+              changeLanguage(currentLanguage === "en" ? "mong" : "en")
+            }
+            color="primary"
+            name="language-toggle"
+            inputProps={{ "aria-label": "language toggle" }}
+          />
+        }
+        label={
+          currentLanguage === "en" ? "Switch to Mongolian" : "Switch to English"
+        }
+      />
+    </div>
+  );
+};
+
+export default LangChange;

--- a/frontend/src/components/multi-Lang/Language.tsx
+++ b/frontend/src/components/multi-Lang/Language.tsx
@@ -1,0 +1,5 @@
+// this might be used to support future language
+export const LANGUAGES = [
+  { label: "English", code: "en" },
+  { label: "Mongolian", code: "mong" },
+];

--- a/frontend/src/components/multi-Lang/i18n.ts
+++ b/frontend/src/components/multi-Lang/i18n.ts
@@ -1,0 +1,50 @@
+import i18n from "i18next"; // The core i18n library
+import { initReactI18next } from "react-i18next"; // Integrates i18n with React
+import i18nBackend from "i18next-http-backend"; // Backend plugin to load translations from a server
+
+// Initialize i18n with the necessary configurations
+i18n
+  .use(i18nBackend) // Use the backend plugin to load translations from an external source
+  .use(initReactI18next) // Integrate i18n with React
+  .init({
+    fallbackLng: "en", // Fallback language if the selected language is not available
+    lng: "en", // Default language to use (English in this case)
+    interpolation: {
+      escapeValue: false, // Prevents escaping of values (React handles XSS protection automatically)
+    },
+    resources: {
+      en: {
+        translation: {
+          title: "Multi-language app",
+          label: "Select another language!",
+          about: "About",
+          home: "Home",
+          text: "Hello! Welcome to GreenZone's multi-language app🐐",
+        },
+      },
+      mong: {
+        translation: {
+          title: "Aplicación en varios idiomas",
+          label: "Selecciona otro lenguaje!",
+          about: "Sobre mí",
+          home: "Inicio",
+          text: "Сайн байна уу! GreenZone-н олон хэл дээрх програмд ​​тавтай морилно уу🐐",
+        },
+      },
+    },
+    // backend: {
+    //   // Configuring the path for loading translation files
+    //   loadPath: "http://localhost:3005/languages/{{lng}}-translation.json", // URL pattern to fetch translations
+    // },
+  })
+  .then(() => {
+    // This logs once i18n has been successfully initialized
+    console.log("i18n initialized:", i18n);
+  })
+  .catch((error) => {
+    // If initialization fails, log the error
+    console.error("i18n initialization failed:", error);
+  });
+
+// Export the i18n instance for use in your app
+export default i18n;

--- a/frontend/src/pages/lang.tsx
+++ b/frontend/src/pages/lang.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import "../components/multi-Lang/i18n"; // This will trigger i18n initialization
+import LangChange from "../components/multi-Lang/LangSwitch";
+
+const Lang = () => {
+  const { t } = useTranslation();
+
+  return (
+    <main className="lang-container">
+      <LangChange />
+      <section className="content-section">
+        <h1 className="title">{t("home")}</h1>
+        <h2 className="subtitle">{t("about")}</h2>
+        <h3 className="title">{t("title")}</h3>
+        <p className="label">{t("label")}</p>
+        <p className="text">{t("text")}</p>
+      </section>
+    </main>
+  );
+};
+
+export default Lang;


### PR DESCRIPTION
## Overview

This ticket focuses on implementing a dual-language feature for the website, addressing the task outlined in [ticket #34](https://github.com/cornellh4i/greenzone/issues/34). The goal is to enable seamless language switching between English and Mongolian. To achieve this, I researched methods for integrating a dual-language approach using i18n, with all changes implemented on the frontend for better user accessibility and localization."

## Testing

I tested the implementation by adding new languages (English, Mongolian, Italian, Spanish), using console logs to track the changes in `i18n`, and verifying the updates directly on the website. Additionally, I conducted smaller-scale testing using another [repository](https://github.com/LiuBrianna/multiLangTest) to ensure the functionality worked as expected.

## Impact

GreenZone is designed to cater to both English and Mongolian users. To enhance accessibility and broaden its reach, we need to implement a language switcher, allowing users to easily toggle between the two languages.

## Screenshots

This is the English format:
<img width="394" alt="image" src="https://github.com/user-attachments/assets/f5f39704-f8e2-44e4-9dd0-c3dbe29e3707">

This is the Mongolian format:
<img width="537" alt="image" src="https://github.com/user-attachments/assets/9d4775d8-097a-4126-90f2-a7eaa363efc5">

## Notes

- Implement backend translation functionality.
- Enhance the feature by utilizing the user's device settings to automatically detect and translate content.
- To accommodate a larger user base, we can extend language support beyond just English and Mongolian.
