### PR TITLE
Made changes to hexagon functionality

### DIFF
--- a/backend/src/controller/Hexagon.ts
+++ b/backend/src/controller/Hexagon.ts
@@ -49,6 +49,52 @@ export const getHexagons = async (
   }
 };
 
+export const getBelowHexagons = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const hexagonsBelow = await Hexagon.find({ bm_pred: { $lte: 0.4 } });
+
+    res.status(200).json(hexagonsBelow);
+  } catch (error: any) {
+    // Use 'any' type
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getAtCapHexagons = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const hexagonsAtCap = await Hexagon.find({
+      bm_pred: { $gt: 0.4, $lt: 0.6 },
+    });
+
+    res.status(200).json(hexagonsAtCap);
+  } catch (error: any) {
+    // Use 'any' type
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getAboveHexagons = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const hexagonsAbove = await Hexagon.find({
+      bm_pred: { $gte: 0.6 },
+    });
+
+    res.status(200).json(hexagonsAbove);
+  } catch (error: any) {
+    // Use 'any' type
+    res.status(500).json({ message: error.message });
+  }
+};
+
 // Update a hexagon
 export const updateHexagon = async (
   req: Request,

--- a/backend/src/controller/Hexagon.ts
+++ b/backend/src/controller/Hexagon.ts
@@ -12,15 +12,14 @@ export const createHexagon = async (
     // Define the hexagon object based on the new structure
     const hexagonData = {
       grid_id: feature.properties.grid_id,
-      grid_area: feature.properties.grid_area,
       aid: feature.properties.aid,
       sid: feature.properties.sid,
       asid: feature.properties.asid,
-      soum_utm_crs: feature.properties.soum_utm_crs,
-      attribute_1: feature.properties.attribute_1,
+      utm_crs: feature.properties.utm_crs,
+      bm_pred: feature.properties.bm_pred,
       area_km2: feature.properties.area_km2,
-      province_number_of_livestock: feature.properties.livestock,
-      province_herders: feature.properties.herders,
+      livestock: feature.properties.livestock,
+      herders: feature.properties.herders,
       geometry: feature.geometry,
     };
 

--- a/backend/src/models/Hexagon.ts
+++ b/backend/src/models/Hexagon.ts
@@ -17,10 +17,6 @@ const hexagonSchema = new Schema({
       required: true,
     },
   },
-  grid_area: {
-    type: Number,
-    required: true,
-  },
   aid: {
     type: Number,
     required: true,
@@ -33,11 +29,11 @@ const hexagonSchema = new Schema({
     type: Number,
     required: true,
   },
-  soum_utm_crs: {
+  utm_crs: {
     type: Number,
     required: true,
   },
-  attribute_1: {
+  bm_pred: {
     type: Number,
     required: false, // Optional, specify required: true if it's mandatory
   },

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -2,6 +2,9 @@ import express from "express";
 import {
   createHexagon,
   getHexagons,
+  getBelowHexagons,
+  getAtCapHexagons,
+  getAboveHexagons,
   updateHexagon,
   deleteHexagon,
 } from "./controller/Hexagon";
@@ -28,6 +31,15 @@ router.post("/hexagons", createHexagon);
 
 // Route to get all hexagons
 router.get("/hexagons", getHexagons);
+
+//Route to get all hexagons with a bm_pred of <= 0.4
+router.get("/hexagons/bm_pred_below", getBelowHexagons);
+
+//Route to get all hexagons with a bm_pred between 0.4 and 0.6
+router.get("/hexagons/bm_pred_at_cap", getAtCapHexagons);
+
+//Route to get all hexagons with a bm_pred between 0.4 and 0.6
+router.get("/hexagons/bm_pred_above", getAboveHexagons);
 
 // Route to update a hexagon
 router.put("/hexagons/:hexagon_id", updateHexagon);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -38,7 +38,7 @@ router.get("/hexagons/bm_pred_below", getBelowHexagons);
 //Route to get all hexagons with a bm_pred between 0.4 and 0.6
 router.get("/hexagons/bm_pred_at_cap", getAtCapHexagons);
 
-//Route to get all hexagons with a bm_pred between 0.4 and 0.6
+//Route to get all hexagons with a bm_pred >= 0.6
 router.get("/hexagons/bm_pred_above", getAboveHexagons);
 
 // Route to update a hexagon

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -315,12 +315,6 @@ const MapComponent = () => {
     filled: true,
     getLineColor: [0, 0, 0],
     getFillColor: [0, 170, 60, 200],
-    // getFillColor: (d) => {
-    //   if (d.bm_pred <= 0.4) {
-    //     return [0, 170, 60, 200];
-    //   }
-    //   return [214, 15, 2, 150];
-    // },
     lineWidthMinPixels: 1,
     updateTriggers: {
       getFillColor: belowHexagons.map((d) => d.bm_pred),

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -343,10 +343,10 @@ const MapComponent = () => {
           label="Toggle Hexagons"
           onClick={() => setShowHexagons((prev) => !prev)}
         />
-        <Button
+        {/* <Button
           label="Toggle Counties"
           onClick={() => setShowCounties((prev) => !prev)}
-        />
+        /> */}
       </div>
       <Map
         initialViewState={INITIAL_VIEW_STATE}

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -447,6 +447,7 @@ const MapComponent = () => {
     showCounties,
     map,
   ]);
+  // meow meow meow
 
   const zoomToProvince = (province: Geometry) => {
     const [sw, ne] = province.view; // Assuming `view` has the SW and NE bounds
@@ -507,10 +508,10 @@ const MapComponent = () => {
           highlightProvince={highlightProvince}
         />
 
-        {/* <Button
+        <Button
           label="Toggle Hexagons"
           onClick={() => setShowHexagons((prev) => !prev)}
-        /> */}
+        />
         {/* <Button
           label="Toggle Counties"
           onClick={() => setShowCounties((prev) => !prev)}

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -147,11 +147,16 @@ const MapComponent = () => {
     const centerLng = (sw[0] + ne[0]) / 2; // Average longitude
     const centerLat = (sw[1] + ne[1]) / 2;
 
+    const lngDiff = ne[0] - sw[0];
+    const latDiff = ne[1] - sw[1];
+
+    const zoom = Math.floor(8 - Math.log2(Math.max(latDiff, lngDiff)));
+
     setViewState((prev) => ({
       ...prev,
-      longitude: centerLng - 1.5, // Center longitude & adjust to right to avoid sidepanel coverage
+      longitude: centerLng, // Center longitude & adjust to right to avoid sidepanel coverage
       latitude: centerLat, // Center latitude
-      zoom: 6.5, // Adjust zoom level as needed
+      zoom: zoom, // Adjust zoom level as needed
       transitionDuration: 1000, // Smooth animation
       transitionInterpolator: new FlyToInterpolator({ curve: 1.5, speed: 1.2 }),
     }));
@@ -212,6 +217,9 @@ const MapComponent = () => {
     if (object) {
       setClickInfo(object.provinceName);
       handleZoomToProvince(object.view);
+      setTimeout(() => {
+        setClickInfo(null);
+      }, 100);
     } else {
       setClickInfo(null);
     }
@@ -320,7 +328,7 @@ const MapComponent = () => {
     layers.push(countryLayer);
     layers.push(provinceLayer);
     if (showHexagons) layers.push(hexagonLayer);
-    if (showCounties) layers.push(countyLayer);
+    // if (showCounties) layers.push(countyLayer);
 
     const overlay = new MapboxOverlay({ layers });
 

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Map, MapRef } from "react-map-gl/maplibre";
+import {FlyToInterpolator} from '@deck.gl/core';
 import { PolygonLayer } from "deck.gl";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import * as d3Geo from "d3-geo";
@@ -27,6 +28,7 @@ export interface Geometry {
   provinceName: string | null;
   provinceLandArea: number | 0;
   provinceHerders: number | 0;
+  view: [[number, number], [number, number]];
   livestock: {
     [key: string] : number | 0
   };
@@ -84,6 +86,18 @@ const MapComponent = () => {
     
       const deckProvinceProj = geojsonData.map((feature: any) => {
         const utmCoordinates = feature.geometry.coordinates[0];
+        const zoomCoordinates = (() => {
+          let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity;
+        
+          utmCoordinates.forEach(([lng, lat]) => {
+            if (lng < minLng) minLng = lng;
+            if (lat < minLat) minLat = lat;
+            if (lng > maxLng) maxLng = lng;
+            if (lat > maxLat) maxLat = lat;
+          });
+          console.log([[minLng, minLat], [maxLng, maxLat]]);
+          return [[minLng, minLat], [maxLng, maxLat]];
+        })();
         const provinceName = feature.province_name;
         const provinceLandArea = feature.province_land_area;
         const provinceHerders = feature.province_herders;
@@ -94,13 +108,36 @@ const MapComponent = () => {
         const camel = feature.province_number_of_camel;
         const horse = feature.province_number_of_horse;
   
-        return { type: "Polygon", coordinates: [utmCoordinates], provinceName: provinceName, provinceLandArea: provinceLandArea, provinceHerders: provinceHerders, livestock: livestock, cattle: cattle, goat: goat, sheep: sheep, camel: camel, horse: horse };
+        return { type: "Polygon", coordinates: [utmCoordinates], provinceName: provinceName, 
+        provinceLandArea: provinceLandArea, provinceHerders: provinceHerders, 
+        view: zoomCoordinates, livestock: livestock, cattle: cattle, goat: goat,
+        sheep: sheep, camel: camel, horse: horse };
       });
   
       setProvinces(deckProvinceProj);
     } catch (error) {
       console.error("Error fetching province data:", error);
     }
+  };
+
+  const handleZoomToProvince = (zoomCoords: [[number, number], [number, number]]) => {
+    console.log("zoom:", zoomCoords);
+    const sw = zoomCoords[0];
+    console.log("sw:", sw)
+    const ne = zoomCoords[1];
+    console.log("ne:", ne)
+
+    const centerLng = (sw[0] + ne[0]) / 2; // Average longitude
+    const centerLat = (sw[1] + ne[1]) / 2;
+
+    setViewState((prev) => ({
+      ...prev,
+      longitude: centerLng - 1.5, // Center longitude & adjust to right to avoid sidepanel coverage
+      latitude: centerLat,  // Center latitude
+      zoom: 6.5, // Adjust zoom level as needed
+      transitionDuration: 1000, // Smooth animation
+      transitionInterpolator: new FlyToInterpolator({ curve: 1.5, speed: 1.2 }),
+    }));
   };
   
 
@@ -170,9 +207,10 @@ const MapComponent = () => {
     });
   }, []);
 
-  const handleProvinceClick = ({ object }: { object: { provinceName: string } | null }) => {
+  const handleProvinceClick = ({ object }: { object: { provinceName: string, view: [[number, number], [number, number]] } | null }) => {
     if (object) {
       setClickInfo(object.provinceName);
+      handleZoomToProvince(object.view);
     } else {
       setClickInfo(null);
     }
@@ -312,10 +350,14 @@ const MapComponent = () => {
       </div>
       <Map
         initialViewState={INITIAL_VIEW_STATE}
+        {...viewState}
         mapStyle={MAP_STYLE}
         cursor={isHovered ? "pointer" : "grab"}
         style={{ width: "100vw", height: "100vh", }}
         onLoad={handleMapLoad}
+        onMove={(evt) => setViewState(evt.viewState)}
+        interactiveLayerIds={[]} // Disable default interactivity
+        controller={true}
       />
       {/* {hoverInfo && (
         <div

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -178,6 +178,7 @@ const MapComponent = () => {
       const deckHexProj = geojsonData.map((feature: any) => {
         return {
           vertices: feature.geometry.coordinates[0], // Polygon vertices
+          bm_pred: feature.bm_pred,
         };
       });
       setHexagons(deckHexProj);
@@ -244,11 +245,19 @@ const MapComponent = () => {
     data: hexagons,
     getPolygon: (d) => d.vertices,
     stroked: true,
-    filled: false,
+    filled: true,
     getLineColor: [0, 0, 0],
+    getFillColor: (d) => {
+      if (d.bm_pred <= 0.4) {
+        return [0, 170, 60, 200];
+      } else if (d.bm_pred < 0.6) {
+        return [255, 255, 20, 150];
+      }
+      return [214, 15, 2, 150];
+    },
     lineWidthMinPixels: 1,
     updateTriggers: {
-      getPolygon: [viewState.zoom], // Ensure smooth adaptation
+      getFillColor: hexagons.map((d) => d.bm_pred),
     },
   });
 

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -7,7 +7,6 @@ import proj4 from "proj4";
 import "maplibre-gl/dist/maplibre-gl.css";
 import Button from "./atoms/Button";
 import SidePanel from "@/components/organisms/SidePanel";
-import { get } from "http";
 
 
 const INITIAL_VIEW_STATE = {
@@ -22,10 +21,30 @@ interface Hexagon {
   vertices: [number, number][];
 }
 
-interface Geometry {
+export interface Geometry {
   type: string;
   coordinates: number[][][] | number[][];
-  province_name: string | null;
+  provinceName: string | null;
+  provinceLandArea: number | 0;
+  provinceHerders: number | 0;
+  livestock: {
+    [key: string] : number | 0
+  };
+  cattle: {
+    [key: string] : number | 0
+  };
+  goat: {
+    [key: string] : number | 0
+  };
+  sheep: {
+    [key: string] : number | 0
+  };
+  camel: {
+    [key: string] : number | 0
+  };
+  horse: {
+    [key: string] : number | 0
+  };
 }
 
 
@@ -44,7 +63,7 @@ const MapComponent = () => {
   const [showHexagons, setShowHexagons] = useState(false);
   const [showProvinces, setShowProvinces] = useState(false);
   const [showCounties, setShowCounties] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
+  const [isHovered, setIsHovered] = useState<boolean>(false);
   const [clickInfo, setClickInfo] = useState<string | null>(null);
 
 
@@ -66,8 +85,16 @@ const MapComponent = () => {
       const deckProvinceProj = geojsonData.map((feature: any) => {
         const utmCoordinates = feature.geometry.coordinates[0];
         const provinceName = feature.province_name;
+        const provinceLandArea = feature.province_land_area;
+        const provinceHerders = feature.province_herders;
+        const livestock = feature.province_number_of_livestock;
+        const cattle = feature.province_number_of_cattle;
+        const goat = feature.province_number_of_goat;
+        const sheep = feature.province_number_of_sheep;
+        const camel = feature.province_number_of_camel;
+        const horse = feature.province_number_of_horse;
   
-        return { type: "Polygon", coordinates: [utmCoordinates], provinceName: provinceName };
+        return { type: "Polygon", coordinates: [utmCoordinates], provinceName: provinceName, provinceLandArea: provinceLandArea, provinceHerders: provinceHerders, livestock: livestock, cattle: cattle, goat: goat, sheep: sheep, camel: camel, horse: horse };
       });
   
       setProvinces(deckProvinceProj);
@@ -213,6 +240,13 @@ const MapComponent = () => {
     autoHighlight: true, 
     highlightColor: [20, 20, 20, 20], 
     onClick: handleProvinceClick,
+    onHover: ({ object }) => {
+      if (object) {
+        setIsHovered(true);
+      } else {
+        setIsHovered(false);
+      }
+    }
   });
   // console.log("Provinces data:", provinces);
   // console.log(clickInfo);
@@ -266,7 +300,7 @@ const MapComponent = () => {
   return (
     <>
       <div style={{ position: "absolute", top: 10, left: 10, zIndex: 1 }}>
-        <SidePanel provinceName={clickInfo}/>
+        <SidePanel data={provinces} provinceName={clickInfo}/>
         <Button
           label="Toggle Hexagons"
           onClick={() => setShowHexagons((prev) => !prev)}
@@ -279,7 +313,8 @@ const MapComponent = () => {
       <Map
         initialViewState={INITIAL_VIEW_STATE}
         mapStyle={MAP_STYLE}
-        style={{ width: "100vw", height: "100vh" }}
+        cursor={isHovered ? "pointer" : "grab"}
+        style={{ width: "100vw", height: "100vh", }}
         onLoad={handleMapLoad}
       />
       {/* {hoverInfo && (

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -350,10 +350,10 @@ const MapComponent = () => {
           setShowHexagons={setShowHexagons}
         />
 
-        <Button
+        {/* <Button
           label="Toggle Hexagons"
           onClick={() => setShowHexagons((prev) => !prev)}
-        />
+        /> */}
         {/* <Button
           label="Toggle Counties"
           onClick={() => setShowCounties((prev) => !prev)}

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -344,7 +344,12 @@ const MapComponent = () => {
   return (
     <>
       <div style={{ position: "absolute", top: 10, left: 10, zIndex: 1 }}>
-        <SidePanel data={provinces} provinceName={clickInfo} />
+        <SidePanel
+          data={provinces}
+          provinceName={clickInfo}
+          setShowHexagons={setShowHexagons}
+        />
+
         <Button
           label="Toggle Hexagons"
           onClick={() => setShowHexagons((prev) => !prev)}

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -14,9 +14,14 @@ import { select } from "d3";
 interface SidePanelProps {
   data: Geometry[];
   provinceName?: string | null;
+  setShowHexagons: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
+const SidePanel: React.FC<SidePanelProps> = ({
+  data,
+  provinceName,
+  setShowHexagons,
+}) => {
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
   // const yearRange = [2007, 2014]; // example year range
   const [filteredData, setFilteredData] = useState<any[]>([]);
@@ -24,7 +29,6 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [selectedAimag, setSelectedAimag] = useState<string | null>(null);
   const [provinceData, setProvinceData] = useState<any | null>(null); // State to store province data
-
 
   const loadProvince = (province: string) => {
     const year = selectedYear || 2014;
@@ -34,23 +38,17 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
     const province_herders = provinceData.provinceHerders;
 
     const selectedYearData = {
-      number_of_livestock:
-        provinceData.livestock[year],
-      number_of_cattle:
-        provinceData.cattle[year],
-        // json_object.province_number_of_cattle[selectedYear || 2014],
-      number_of_goat:
-        provinceData.goat[year],
-        // json_object.province_number_of_goat[selectedYear || 2014],
-      number_of_sheep:
-        provinceData.sheep[year],
-        // json_object.province_number_of_sheep[selectedYear || 2014],
-      number_of_camel:
-        provinceData.camel[year],
-        // json_object.province_number_of_camel[selectedYear || 2014],
-      number_of_horse:
-        provinceData.horse[year],
-        // json_object.province_number_of_horse[selectedYear || 2014],
+      number_of_livestock: provinceData.livestock[year],
+      number_of_cattle: provinceData.cattle[year],
+      // json_object.province_number_of_cattle[selectedYear || 2014],
+      number_of_goat: provinceData.goat[year],
+      // json_object.province_number_of_goat[selectedYear || 2014],
+      number_of_sheep: provinceData.sheep[year],
+      // json_object.province_number_of_sheep[selectedYear || 2014],
+      number_of_camel: provinceData.camel[year],
+      // json_object.province_number_of_camel[selectedYear || 2014],
+      number_of_horse: provinceData.horse[year],
+      // json_object.province_number_of_horse[selectedYear || 2014],
     };
 
     const formattedData = livestockTypes.map((livestockType) => ({
@@ -58,14 +56,14 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
       y: selectedYearData[`number_of_${livestockType.toLowerCase()}`] || 0,
     }));
 
-
     setProvinceData({
       province_name,
       province_land_area,
       province_herders,
       selectedYearData,
       formattedData,
-    })};
+    });
+  };
 
   //   try {
   //     const response = await fetch(
@@ -123,8 +121,6 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
     setSelectedAimag(aimag);
   };
 
-
-
   const handleYearSlider = (year: number) => {
     setSelectedYear(year);
   };
@@ -133,7 +129,6 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
     setSelectedAimag(null);
     setProvinceData(null);
   };
-
 
   useEffect(() => {
     if (provinceName) {
@@ -152,6 +147,11 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
 
   const handleOptionChange = (value: string) => {
     setSelectedOption(value);
+    if (value === "carryingCapacity") {
+      setShowHexagons(true);
+    } else {
+      setShowHexagons(false);
+    }
   };
 
   const options = [
@@ -178,7 +178,6 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
       ),
     },
   ];
-
 
   return (
     <div>

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -15,12 +15,22 @@ interface SidePanelProps {
   data: Geometry[];
   provinceName?: string | null;
   setShowHexagons: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowBelowHexagons: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowAtCapHexagons: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowAboveHexagons: React.Dispatch<React.SetStateAction<boolean>>;
+  zoomToProvince: (province: Geometry) => void; // Add this
+  highlightProvince?: (province: Geometry | null) => void; // Optional
 }
 
 const SidePanel: React.FC<SidePanelProps> = ({
   data,
   provinceName,
   setShowHexagons,
+  setShowBelowHexagons,
+  setShowAtCapHexagons,
+  setShowAboveHexagons,
+  zoomToProvince,
+  highlightProvince,
 }) => {
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
   // const yearRange = [2007, 2014]; // example year range
@@ -65,60 +75,24 @@ const SidePanel: React.FC<SidePanelProps> = ({
     });
   };
 
-  //   try {
-  //     const response = await fetch(
-  //       `http://localhost:8080/api/province/${selectedAimag}`
-  //     );
-  //     const json_object = await response.json();
-
-  //     // Extract general information (non-year dependent)
-  //     const { province_name, province_land_area, province_herders } =
-  //       json_object;
-
-  //     // Extract year-dependent livestock data based on the selected year
-  //     const selectedYearData = {
-  //       number_of_livestock:
-  //         json_object.province_number_of_livestock[selectedYear || 2014],
-  //       number_of_cattle:
-  //         json_object.province_number_of_cattle[selectedYear || 2014],
-  //       number_of_goat:
-  //         json_object.province_number_of_goat[selectedYear || 2014],
-  //       number_of_sheep:
-  //         json_object.province_number_of_sheep[selectedYear || 2014],
-  //       number_of_camel:
-  //         json_object.province_number_of_camel[selectedYear || 2014],
-  //       number_of_horse:
-  //         json_object.province_number_of_horse[selectedYear || 2014],
-  //     };
-
-  //     // Format data for the bar chart
-  //     const formattedData = livestockTypes.map((livestockType) => ({
-  //       x: livestockType,
-  //       y: selectedYearData[`number_of_${livestockType.toLowerCase()}`] || 0,
-  //     }));
-
-  //     // Combine general information with year-specific data
-  //     setProvinceData({
-  //       province_name,
-  //       province_land_area,
-  //       province_herders,
-  //       selectedYearData,
-  //       formattedData,
-  //     });
-  //   } catch (error) {
-  //     console.error("Error fetching data from Express:", error);
-  //   }
-  // };
-
   const handlePanelToggle = () => {
     setIsPanelOpen(!isPanelOpen);
     setSelectedAimag(null);
-    setProvinceData(null); // Clear province data when closing panel
+    setProvinceData(null);
     setSelectedYear(2014);
   };
 
   const handleProvinceSearch = (aimag: string | null) => {
     setSelectedAimag(aimag);
+
+    const province = data.find((d) => d.provinceName === aimag);
+
+    if (province) {
+      zoomToProvince(province); // Call the function passed from the parent
+      if (highlightProvince) highlightProvince(province); // Optional highlight
+    } else {
+      if (highlightProvince) highlightProvince(null); // Reset highlight
+    }
   };
 
   const handleYearSlider = (year: number) => {
@@ -160,9 +134,33 @@ const SidePanel: React.FC<SidePanelProps> = ({
       label: "Carrying Capacity",
       content: (
         <div style={{ display: "flex", gap: "10px" }}>
-          <Button onClick={() => {}} label="Below" />
-          <Button onClick={() => {}} label="At Capacity" />
-          <Button onClick={() => {}} label="Above" />
+          <Button
+            onClick={() => {
+              setShowBelowHexagons(true);
+              setShowAtCapHexagons(false);
+              setShowHexagons(false);
+              setShowAboveHexagons(false);
+            }}
+            label="Below"
+          />
+          <Button
+            onClick={() => {
+              setShowAtCapHexagons(true);
+              setShowHexagons(false);
+              setShowBelowHexagons(false);
+              setShowAboveHexagons(false);
+            }}
+            label="At Capacity"
+          />
+          <Button
+            onClick={() => {
+              setShowAtCapHexagons(false);
+              setShowHexagons(false);
+              setShowBelowHexagons(false);
+              setShowAboveHexagons(true);
+            }}
+            label="Above"
+          />
         </div>
       ),
     },

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -125,6 +125,9 @@ const SidePanel: React.FC<SidePanelProps> = ({
       setShowHexagons(true);
     } else {
       setShowHexagons(false);
+      setShowAboveHexagons(false);
+      setShowBelowHexagons(false);
+      setShowAtCapHexagons(false);
     }
   };
 

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -9,7 +9,11 @@ import RadioButton from "@/components/atoms/RadioButton";
 import Slide from "@/components/atoms/Slide";
 import Toggle from "@/components/atoms/Toggle";
 
-const SidePanel = () => {
+interface SidePanelProps {
+  provinceName?: string | null;
+}
+
+const SidePanel: React.FC<SidePanelProps> = ({ provinceName }) => {
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
   const yearRange = [2007, 2014]; // example year range
   const [filteredData, setFilteredData] = useState<any[]>([]);
@@ -17,6 +21,7 @@ const SidePanel = () => {
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [selectedAimag, setSelectedAimag] = useState<string | null>(null);
   const [provinceData, setProvinceData] = useState<any | null>(null); // State to store province data
+
 
   const loadProvince = async () => {
     try {
@@ -74,6 +79,8 @@ const SidePanel = () => {
     setSelectedAimag(aimag);
   };
 
+
+
   const handleYearSlider = (year: number) => {
     setSelectedYear(year);
   };
@@ -83,11 +90,20 @@ const SidePanel = () => {
     setProvinceData(null);
   };
 
+
+  useEffect(() => {
+    if (provinceName) {
+      setSelectedAimag(provinceName);
+      setIsPanelOpen(true);
+    }
+  }, [provinceName]);
+
   useEffect(() => {
     if (selectedAimag) {
       loadProvince();
     }
   }, [selectedAimag]);
+
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
   const handleOptionChange = (value: string) => {
@@ -118,6 +134,7 @@ const SidePanel = () => {
       ),
     },
   ];
+
 
   return (
     <div>

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -188,6 +188,9 @@ const SidePanel: React.FC<SidePanelProps> = ({
             anchor="left"
             open={isPanelOpen}
             onClose={handlePanelToggle}
+            ModalProps={{
+              BackdropProps: { invisible: true },
+            }}
             PaperProps={{
               sx: {
                 width: "80%",

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -9,75 +9,114 @@ import RadioButton from "@/components/atoms/RadioButton";
 import Slide from "@/components/atoms/Slide";
 import Toggle from "@/components/atoms/Toggle";
 import { Geometry } from "../Map";
+import { select } from "d3";
 
 interface SidePanelProps {
-  data?: Geometry[];
+  data: Geometry[];
   provinceName?: string | null;
 }
 
 const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
-  const yearRange = [2007, 2014]; // example year range
+  // const yearRange = [2007, 2014]; // example year range
   const [filteredData, setFilteredData] = useState<any[]>([]);
-  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+  const [selectedYear, setSelectedYear] = useState<number>(2014);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [selectedAimag, setSelectedAimag] = useState<string | null>(null);
   const [provinceData, setProvinceData] = useState<any | null>(null); // State to store province data
 
-  console.log(data);
+
+  const loadProvince = (province: string) => {
+    const year = selectedYear || 2014;
+    const provinceData = data.find((d) => d.provinceName === province);
+    const province_name = provinceData.provinceName;
+    const province_land_area = provinceData.provinceLandArea;
+    const province_herders = provinceData.provinceHerders;
+
+    const selectedYearData = {
+      number_of_livestock:
+        provinceData.livestock[year],
+      number_of_cattle:
+        provinceData.cattle[year],
+        // json_object.province_number_of_cattle[selectedYear || 2014],
+      number_of_goat:
+        provinceData.goat[year],
+        // json_object.province_number_of_goat[selectedYear || 2014],
+      number_of_sheep:
+        provinceData.sheep[year],
+        // json_object.province_number_of_sheep[selectedYear || 2014],
+      number_of_camel:
+        provinceData.camel[year],
+        // json_object.province_number_of_camel[selectedYear || 2014],
+      number_of_horse:
+        provinceData.horse[year],
+        // json_object.province_number_of_horse[selectedYear || 2014],
+    };
+
+    const formattedData = livestockTypes.map((livestockType) => ({
+      x: livestockType,
+      y: selectedYearData[`number_of_${livestockType.toLowerCase()}`] || 0,
+    }));
 
 
-  const loadProvince = async () => {
-    try {
-      const response = await fetch(
-        `http://localhost:8080/api/province/${selectedAimag}`
-      );
-      const json_object = await response.json();
+    setProvinceData({
+      province_name,
+      province_land_area,
+      province_herders,
+      selectedYearData,
+      formattedData,
+    })};
 
-      // Extract general information (non-year dependent)
-      const { province_name, province_land_area, province_herders } =
-        json_object;
-        console.log(json_object);
+  //   try {
+  //     const response = await fetch(
+  //       `http://localhost:8080/api/province/${selectedAimag}`
+  //     );
+  //     const json_object = await response.json();
 
-      // Extract year-dependent livestock data based on the selected year
-      const selectedYearData = {
-        number_of_livestock:
-          json_object.province_number_of_livestock[selectedYear || 2014],
-        number_of_cattle:
-          json_object.province_number_of_cattle[selectedYear || 2014],
-        number_of_goat:
-          json_object.province_number_of_goat[selectedYear || 2014],
-        number_of_sheep:
-          json_object.province_number_of_sheep[selectedYear || 2014],
-        number_of_camel:
-          json_object.province_number_of_camel[selectedYear || 2014],
-        number_of_horse:
-          json_object.province_number_of_horse[selectedYear || 2014],
-      };
+  //     // Extract general information (non-year dependent)
+  //     const { province_name, province_land_area, province_herders } =
+  //       json_object;
 
-      // Format data for the bar chart
-      const formattedData = livestockTypes.map((livestockType) => ({
-        x: livestockType,
-        y: selectedYearData[`number_of_${livestockType.toLowerCase()}`] || 0,
-      }));
+  //     // Extract year-dependent livestock data based on the selected year
+  //     const selectedYearData = {
+  //       number_of_livestock:
+  //         json_object.province_number_of_livestock[selectedYear || 2014],
+  //       number_of_cattle:
+  //         json_object.province_number_of_cattle[selectedYear || 2014],
+  //       number_of_goat:
+  //         json_object.province_number_of_goat[selectedYear || 2014],
+  //       number_of_sheep:
+  //         json_object.province_number_of_sheep[selectedYear || 2014],
+  //       number_of_camel:
+  //         json_object.province_number_of_camel[selectedYear || 2014],
+  //       number_of_horse:
+  //         json_object.province_number_of_horse[selectedYear || 2014],
+  //     };
 
-      // Combine general information with year-specific data
-      setProvinceData({
-        province_name,
-        province_land_area,
-        province_herders,
-        selectedYearData,
-        formattedData,
-      });
-    } catch (error) {
-      console.error("Error fetching data from Express:", error);
-    }
-  };
+  //     // Format data for the bar chart
+  //     const formattedData = livestockTypes.map((livestockType) => ({
+  //       x: livestockType,
+  //       y: selectedYearData[`number_of_${livestockType.toLowerCase()}`] || 0,
+  //     }));
+
+  //     // Combine general information with year-specific data
+  //     setProvinceData({
+  //       province_name,
+  //       province_land_area,
+  //       province_herders,
+  //       selectedYearData,
+  //       formattedData,
+  //     });
+  //   } catch (error) {
+  //     console.error("Error fetching data from Express:", error);
+  //   }
+  // };
 
   const handlePanelToggle = () => {
     setIsPanelOpen(!isPanelOpen);
     setSelectedAimag(null);
     setProvinceData(null); // Clear province data when closing panel
+    setSelectedYear(2014);
   };
 
   const handleProvinceSearch = (aimag: string | null) => {
@@ -225,9 +264,9 @@ const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
 
                       <Slide
                         name="Year"
-                        selectedValue={2014}
+                        selectedValue={selectedYear}
                         onChange={handleYearSlider}
-                        min={2007}
+                        min={2002}
                         max={2014}
                       />
                       <hr

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -8,12 +8,14 @@ import { Box, Drawer } from "@mui/material";
 import RadioButton from "@/components/atoms/RadioButton";
 import Slide from "@/components/atoms/Slide";
 import Toggle from "@/components/atoms/Toggle";
+import { Geometry } from "../Map";
 
 interface SidePanelProps {
+  data?: Geometry[];
   provinceName?: string | null;
 }
 
-const SidePanel: React.FC<SidePanelProps> = ({ provinceName }) => {
+const SidePanel: React.FC<SidePanelProps> = ({ data, provinceName }) => {
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
   const yearRange = [2007, 2014]; // example year range
   const [filteredData, setFilteredData] = useState<any[]>([]);
@@ -21,6 +23,8 @@ const SidePanel: React.FC<SidePanelProps> = ({ provinceName }) => {
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [selectedAimag, setSelectedAimag] = useState<string | null>(null);
   const [provinceData, setProvinceData] = useState<any | null>(null); // State to store province data
+
+  console.log(data);
 
 
   const loadProvince = async () => {
@@ -33,6 +37,7 @@ const SidePanel: React.FC<SidePanelProps> = ({ provinceName }) => {
       // Extract general information (non-year dependent)
       const { province_name, province_land_area, province_herders } =
         json_object;
+        console.log(json_object);
 
       // Extract year-dependent livestock data based on the selected year
       const selectedYearData = {
@@ -100,7 +105,7 @@ const SidePanel: React.FC<SidePanelProps> = ({ provinceName }) => {
 
   useEffect(() => {
     if (selectedAimag) {
-      loadProvince();
+      loadProvince(selectedAimag);
     }
   }, [selectedAimag]);
 

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -139,28 +139,22 @@ const SidePanel: React.FC<SidePanelProps> = ({
         <div style={{ display: "flex", gap: "10px" }}>
           <Button
             onClick={() => {
-              setShowBelowHexagons(true);
-              setShowAtCapHexagons(false);
+              setShowBelowHexagons((prev) => !prev);
               setShowHexagons(false);
-              setShowAboveHexagons(false);
             }}
             label="Below"
           />
           <Button
             onClick={() => {
-              setShowAtCapHexagons(true);
+              setShowAtCapHexagons((prev) => !prev);
               setShowHexagons(false);
-              setShowBelowHexagons(false);
-              setShowAboveHexagons(false);
             }}
             label="At Capacity"
           />
           <Button
             onClick={() => {
-              setShowAtCapHexagons(false);
               setShowHexagons(false);
-              setShowBelowHexagons(false);
-              setShowAboveHexagons(true);
+              setShowAboveHexagons((prev) => !prev);
             }}
             label="Above"
           />

--- a/frontend/src/pages/about.tsx
+++ b/frontend/src/pages/about.tsx
@@ -13,7 +13,6 @@ export default About;*/
 
 /** An About page */
 const About = () => {
-  console.log("about!");
   return <>{<SimpleMap />}</>;
 };
 

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import NavBar from "../components/molecules/NavBar";
+import Map from "../components/Map";
+
 
 const MonitoringPlatform = () => {
   return (
-    <div className="text-center p-4">
-        <NavBar />
-        <h1 className="text-2xl font-semibold">Hi! This is the Map page</h1>
+    <div>
+      <Map/>
     </div>
   );
 };

--- a/frontend/src/pages/sidepanelpage.tsx
+++ b/frontend/src/pages/sidepanelpage.tsx
@@ -6,7 +6,7 @@ import SidePanel from "@/components/organisms/SidePanel";
 const SidePanelPage = () => {
   return (
     <div>
-      <SidePanel/>
+      <SidePanel data={[]}/>
     </div>
   );
 };

--- a/frontend/src/pages/sidepanelpage.tsx
+++ b/frontend/src/pages/sidepanelpage.tsx
@@ -6,7 +6,7 @@ import SidePanel from "@/components/organisms/SidePanel";
 const SidePanelPage = () => {
   return (
     <div>
-      <SidePanel></SidePanel>
+      <SidePanel/>
     </div>
   );
 };


### PR DESCRIPTION
## Overview

For this ticket, we first changed the polygon shape from hexagons to circles, and then added the toggle functionality into the side bar so that, when using the side bar, clicking on the "Carrying Capacity" radio button will display the circles and clicking out of that radio button will not display the circles. We also implemented the fill for the circles based on the bm_pred values, the fill color following the convention on the ticket description. We also implemented functionality for the Below, At Capacity, and Above buttons. When below is clicked, only the circles that represent parts of the province with bm_pred values of less than or equal to 0.4 is displayed. Similarly, for at capacity, the circles that represent parts of the province with bm_pred values of between 0.4 and 0.6 is displayed, and for above, the circles that represent parts of the province with bm_pred values of greater than or equal to 0.6 is displayed.

## Testing

We tested this feature by first making sure to start the database (run `npm run start` in the backend folder) and run the site (run `yarn run dev` in the frontend folder). Then, navigate to `http://localhost:3000/about`, which contains the side panel and the map components. Click on the Toggle Sidepanel button on the top left hand corner and navigate to the Carrying Capacity radio button. Clicking on that button should display red, yellow, and green circles on the map! Clicking on Z-Score will get rid of the circles that are displayed on the map. Clicking on below should only show green circles, which represents the circles that represent parts of the province with bm_pred values of less than or equal to 0.4. The at capacity and above buttons should work similarly.

## Impact

This will contribute to the project because it starts to display some of the data visually, which is one of the goals for the site.

## Screenshots

<img width="1336" alt="image" src="https://github.com/user-attachments/assets/7ec40aa1-87d1-482a-801a-12d69c2c593e">
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/0961c202-699d-46ca-87d2-d0d039030a83">
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/f0c585a2-eb08-44f4-bd0e-f224f77d4ccc">
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/6c61c4a2-900a-4913-992d-6a79589fd27f">
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/d20b08aa-579b-4ea5-87cd-b73be01db586">
<img width="1426" alt="image" src="https://github.com/user-attachments/assets/5ea32fc6-e0b0-4e77-a0d5-b800f8ad0c52">

