### PR TITLE
Connecting Side Panel to Top Panel (and vice versa)

### DIFF
--- a/backend/src/controller/Province.ts
+++ b/backend/src/controller/Province.ts
@@ -63,10 +63,10 @@ export const getProvinceById = async (
   res: Response
 ): Promise<void> => {
   console.log("wwggeg");
-  const { id } = req.params; // Extract ID from the URL
+  const feature = req.params; // Extract ID from the URL
 
   try {
-    const province = await Province.findById(id);
+    const province = await Province.findById(feature.province_id);
     if (!province) {
       res.status(404).json({ message: "Provinceqwcqwdqwd not found" });
       return;
@@ -83,7 +83,7 @@ export const getProvinceByName = async (
   res: Response
 ): Promise<void> => {
   const { province_name } = req.params;
-
+  console.log(province_name);
   try {
     const province = await Province.findOne({ province_name: province_name });
     if (!province) {
@@ -103,9 +103,10 @@ export const updateProvince = async (
   try {
     const { province_id } = req.params;
     const updatedData = req.body;
-
-    const province = await Province.findByIdAndUpdate(
-      province_id,
+    console.log("were in update");
+    console.log(req.params);
+    const province = await Province.findOneAndUpdate(
+      { province_name: province_id },
       updatedData,
       {
         new: true,

--- a/backend/src/models/County.ts
+++ b/backend/src/models/County.ts
@@ -14,33 +14,24 @@ const countySchema = new Schema({
     type: Number,
     required: true,
   },
-  county_name: {
+  soum_name: {
     type: String,
     required: true,
   },
-  county_land_area: {
-    type: Number,
+  province_name: {
+    type: String,
     required: true,
   },
-  county_number_of_livestock: {
-    type: Number,
-    required: true,
-  },
-  county_number_of_cattle: {
-    type: Number,
-    required: true,
-  },
-  county_number_of_goat: {
-    type: Number,
-    required: true,
-  },
-  county_number_of_sheep: {
-    type: Number,
-    required: true,
-  },
-  county_number_of_camel: {
-    type: Number,
-    required: true,
+  geometry: {
+    type: {
+      type: String,
+      enum: ["Polygon"], // Ensure the geometry type is always "Polygon"
+      required: true,
+    },
+    coordinates: {
+      type: [[[Number]]], // Array of arrays of coordinates for a polygon
+      required: true,
+    },
   },
 });
 

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -3,14 +3,15 @@ import { Button as MuiButton, SxProps } from "@mui/material";
 
 interface ButtonProps {
   onClick: () => void;
-  label: string;
+  label?: string;
   sx?: SxProps;
   disabled?: boolean;
+  startIcon?: React.ReactNode;
 }
 
-const Button: React.FC<ButtonProps> = ({ onClick, label, sx, disabled }) => {
+const Button: React.FC<ButtonProps> = ({ onClick, label, sx, disabled, startIcon }) => {
   return (
-    <MuiButton variant="contained" onClick={onClick} sx={sx} disabled={disabled}>
+    <MuiButton variant="contained" onClick={onClick} sx={sx} disabled={disabled} startIcon={startIcon}>
       {label}
     </MuiButton>
   );

--- a/frontend/src/components/atoms/DropDown.tsx
+++ b/frontend/src/components/atoms/DropDown.tsx
@@ -30,6 +30,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         <TextField {...params} label={label} variant="outlined" sx={sx} />
       )}
       freeSolo
+      disableClearable
     />
   );
 };

--- a/frontend/src/components/atoms/RadioButton.tsx
+++ b/frontend/src/components/atoms/RadioButton.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 interface RadioButtonGroupProps {
-  options: { name: string; label: string; content: React.ReactNode }[]; // Each option can have content under it
+  options: { name: string; label: string; content: React.ReactNode }[];
   selectedOption: string | null;
-  onChange: (value: string) => void; // Handle option change
+  onChange: (value: string) => void;
 }
 
 const RadioButton: React.FC<RadioButtonGroupProps> = ({
@@ -26,8 +26,8 @@ const RadioButton: React.FC<RadioButtonGroupProps> = ({
             <input
               type="radio"
               name="radio-group"
-              checked={selectedOption === option.name}
-              onChange={() => onChange(option.name)}
+              checked={selectedOption === option.name} // Check if the option is selected
+              onChange={() => onChange(option.name)}    // Call onChange when selected
               style={{
                 width: "20px",
                 height: "20px",

--- a/frontend/src/components/molecules/SearchBar.tsx
+++ b/frontend/src/components/molecules/SearchBar.tsx
@@ -17,7 +17,6 @@ const SearchBar: React.FC<SearchBarParams> = ({
 
   const handleSearch = () => {
     if (selectedValue) {
-      console.log(selectedValue);
       // Ensure selectedValue is not null before calling onValueSelect
       onValueSelect({ name: selectedValue });
     }

--- a/frontend/src/components/molecules/Slide.tsx
+++ b/frontend/src/components/molecules/Slide.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Slider, Box } from "@mui/material";
+import Dropdown from "../atoms/DropDown";
 
 interface SlideProps {
   name: string; // Custom name for the slider (e.g., "Year")
@@ -7,6 +8,7 @@ interface SlideProps {
   onChange: (value: number) => void; // Accepts a number
   min: number; // Minimum value of the slider range
   max: number; // Maximum value of the slider range
+  options?: string[];
 }
 
 const Slide: React.FC<SlideProps> = ({
@@ -15,13 +17,21 @@ const Slide: React.FC<SlideProps> = ({
   onChange,
   min,
   max,
+  options,
 }) => {
-  const [value, setValue] = useState<number>(selectedValue || min); // Local state for the slider value
+  const [value, setValue] = useState<number>(selectedValue || max);
 
   const handleSlideChange = (_: Event, newValue: number | number[]) => {
     if (typeof newValue === "number") {
       setValue(newValue); // Update local state
       onChange(newValue); // Call the onChange handler passed from parent
+    }
+  };
+
+  const handleDropdownChange = (newValue: number | null) => {
+    if (newValue !== null) {
+      setValue(newValue);
+      onChange(newValue);
     }
   };
 
@@ -66,7 +76,12 @@ const Slide: React.FC<SlideProps> = ({
               textDecoration: "none",
             }}
           >
-            {value}
+            {<Dropdown
+        options={options}
+        value={value.toString()}
+        onChange={handleDropdownChange}
+        sx={{ width: "64px", alignItems: 'center' }}
+        disableClearable={true}/>}
           </span>
         </Box>
       </Box>
@@ -77,6 +92,30 @@ const Slide: React.FC<SlideProps> = ({
         onChange={handleSlideChange}
         valueLabelDisplay="auto"
       />
+      <Box display="flex" width="100%" justifyContent="space-between" mt={2}>
+        <span
+          style={{
+            fontFamily: "Poppins",
+            fontSize: "14px",
+            lineHeight: "5px",
+            textAlign: "left",
+            color: "black",
+          }}
+        >
+          {min}
+        </span>
+        <span
+          style={{
+            fontFamily: "Poppins",
+            fontSize: "14px",
+            lineHeight: "5px",
+            textAlign: "right",
+            color: "black",
+          }}
+        >
+          {max}
+        </span>
+      </Box>
     </Box>
   );
 };

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -33,6 +33,7 @@ interface SidePanelProps {
   selectedOption: string | "carryingCapacity";
   setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
   yearOptions: string[];
+  displayName: string;
 }
 const SidePanel: React.FC<SidePanelProps> = ({
   provinceName,
@@ -61,19 +62,20 @@ const SidePanel: React.FC<SidePanelProps> = ({
   selectedOption,
   setSelectedOption,
   yearOptions,
+  displayName
 }) => {
   const [provinceData, setProvinceData] = useState<any | null>(null);
 
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
 
   // Fetch data for the selected province
-  const loadProvinceData = async (provinceName: string) => {
+  const loadProvinceData = async (provinceName: string, displayName: string) => {
     try {
-      console.log(provinceName.name);
       const response = await fetch(
         `http://localhost:8080/api/province/${provinceName.name}`
       );
       const json_object = await response.json();
+      console.log(provinceName)
 
       const { province_name, province_land_area, province_herders } =
         json_object;
@@ -99,6 +101,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
       }));
 
       setProvinceData({
+        displayName,
         province_name,
         province_land_area,
         province_herders,
@@ -113,7 +116,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
   useEffect(() => {
     if (provinceName) {
       setIsPanelOpen(true); // Open the panel when a province is selected
-      loadProvinceData(provinceName);
+      loadProvinceData(provinceName, displayName);
     }
   }, [provinceName]);
 
@@ -263,7 +266,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
               <div style={{ position: "absolute", top: "10px", right: "10px" }}>
                 <Button onClick={handleBack} label="Back" />
               </div>
-              <h1>{provinceData.province_name}</h1>
+              <h1>{provinceData.displayName.name}</h1>
               <p>
                 <strong>Land Area:</strong> {provinceData.province_land_area}{" "}
                 km²

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -28,7 +28,7 @@ interface SidePanelProps {
   setShowNegativeCells: React.Dispatch<React.SetStateAction<boolean>>;
   selectedYear: number | 2014;
   setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
-  grazingRange: boolean | null;
+  grazingRange: boolean | false;
   setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const SidePanel: React.FC<SidePanelProps> = ({
@@ -224,7 +224,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
                 max={2014}
               />
               <h2>Grazing Range</h2>
-              <Toggle initialChecked={false} onChange={() => {}} />
+              <Toggle initialChecked={grazingRange} onChange={(checked) => setGrazingRange(checked)} />
               <h2>Data Layers</h2>
               <RadioButton
                 options={options}

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -62,20 +62,23 @@ const SidePanel: React.FC<SidePanelProps> = ({
   selectedOption,
   setSelectedOption,
   yearOptions,
-  displayName
+  displayName,
 }) => {
   const [provinceData, setProvinceData] = useState<any | null>(null);
 
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
 
   // Fetch data for the selected province
-  const loadProvinceData = async (provinceName: string, displayName: string) => {
+  const loadProvinceData = async (
+    provinceName: string,
+    displayName: string
+  ) => {
     try {
       const response = await fetch(
         `http://localhost:8080/api/province/${provinceName.name}`
       );
       const json_object = await response.json();
-      console.log(provinceName)
+      console.log(provinceName);
 
       const { province_name, province_land_area, province_herders } =
         json_object;
@@ -156,8 +159,6 @@ const SidePanel: React.FC<SidePanelProps> = ({
       setShowZeroCells(false);
     }
   };
-
-  
 
   const options = [
     {
@@ -253,7 +254,10 @@ const SidePanel: React.FC<SidePanelProps> = ({
                 options={yearOptions}
               />
               <h2>Grazing Range</h2>
-              <Toggle initialChecked={grazingRange} onChange={(checked) => setGrazingRange(checked)} />
+              <Toggle
+                initialChecked={grazingRange}
+                onChange={(checked) => setGrazingRange(checked)}
+              />
               <h2>Data Layers</h2>
               <RadioButton
                 options={options}
@@ -266,7 +270,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
               <div style={{ position: "absolute", top: "10px", right: "10px" }}>
                 <Button onClick={handleBack} label="Back" />
               </div>
-              <h1>{provinceData.displayName.name}</h1>
+              <h1>{provinceData.province_name}</h1>
               <p>
                 <strong>Land Area:</strong> {provinceData.province_land_area}{" "}
                 km²

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -8,6 +8,8 @@ import Toggle from "@/components/atoms/Toggle";
 
 interface SidePanelProps {
   provinceName: string | null;
+  isPanelOpen: boolean | null;
+  setIsPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
   carryingCapacity: boolean | null;
   setCarryingCapacity: React.Dispatch<React.SetStateAction<boolean>>;
   showBelowCells: boolean | null;
@@ -31,6 +33,8 @@ interface SidePanelProps {
 }
 const SidePanel: React.FC<SidePanelProps> = ({
   provinceName,
+  isPanelOpen,
+  setIsPanelOpen,
   carryingCapacity,
   setCarryingCapacity,
   showBelowCells,
@@ -52,7 +56,6 @@ const SidePanel: React.FC<SidePanelProps> = ({
   grazingRange,
   setGrazingRange,
 }) => {
-  const [isPanelOpen, setIsPanelOpen] = useState(true);
   const [provinceData, setProvinceData] = useState<any | null>(null);
 
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
@@ -137,14 +140,17 @@ const SidePanel: React.FC<SidePanelProps> = ({
           <Button
             onClick={() => setShowBelowCells(!showBelowCells)}
             label="Below"
+            sx={{ backgroundColor: showBelowCells ? "green" : "grey" }}
           />
           <Button
             onClick={() => setShowAtCapCells(!showAtCapCells)}
             label="At Capacity"
+            sx={{ backgroundColor: showAtCapCells ? "#C6BF31" : "grey" }}
           />
           <Button
             onClick={() => setShowAboveCells(!showAboveCells)}
             label="Above"
+            sx={{ backgroundColor: showAboveCells ? "red" : "grey" }}
           />
         </div>
       ),
@@ -154,9 +160,21 @@ const SidePanel: React.FC<SidePanelProps> = ({
       label: "Z-Score",
       content: (
         <div style={{ display: "flex", gap: "10px" }}>
-          <Button onClick={() => {}} label="Positive" />
-          <Button onClick={() => {}} label="Zero" />
-          <Button onClick={() => {}} label="Negative" />
+          <Button
+            onClick={() => setShowPositiveCells(!showPositiveCells)}
+            label="Positive"
+            sx={{ backgroundColor: showPositiveCells ? "teal" : "grey" }}
+          />
+          <Button
+            onClick={() => setShowZeroCells(!showZeroCells)}
+            label="Zero"
+            sx={{ backgroundColor: showZeroCells ? "darkblue" : "grey" }}
+          />
+          <Button
+            onClick={() => setShowNegativeCells(!showNegativeCells)}
+            label="Negative"
+            sx={{ backgroundColor: showNegativeCells ? "purple" : "grey" }}
+          />
         </div>
       ),
     },

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -8,28 +8,55 @@ import Toggle from "@/components/atoms/Toggle";
 
 interface SidePanelProps {
   provinceName: string | null;
+  carryingCapacity: boolean | null;
+  setCarryingCapacity: React.Dispatch<React.SetStateAction<boolean>>;
   showBelowCells: boolean | null;
   setShowBelowCells: React.Dispatch<React.SetStateAction<boolean>>;
   showAtCapCells: boolean | null;
   setShowAtCapCells: React.Dispatch<React.SetStateAction<boolean>>;
   showAboveCells: boolean | null;
   setShowAboveCells: React.Dispatch<React.SetStateAction<boolean>>;
+  ndviSelect: boolean | null;
+  setNdviSelect: React.Dispatch<React.SetStateAction<boolean>>;
+  showPositiveCells: boolean | null;
+  setShowPositiveCells: React.Dispatch<React.SetStateAction<boolean>>;
+  showZeroCells: boolean | null;
+  setShowZeroCells: React.Dispatch<React.SetStateAction<boolean>>;
+  showNegativeCells: boolean | null;
+  setShowNegativeCells: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedYear: number | 2014;
+  setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+  grazingRange: boolean | null;
+  setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
 }
 const SidePanel: React.FC<SidePanelProps> = ({
   provinceName,
+  carryingCapacity,
+  setCarryingCapacity,
   showBelowCells,
   setShowBelowCells,
   showAtCapCells,
   setShowAtCapCells,
   showAboveCells,
   setShowAboveCells,
+  ndviSelect,
+  setNdviSelect,
+  showPositiveCells,
+  setShowPositiveCells,
+  showZeroCells,
+  setShowZeroCells,
+  showNegativeCells,
+  setShowNegativeCells,
+  selectedYear,
+  setSelectedYear,
+  grazingRange,
+  setGrazingRange,
 }) => {
-  const [selectedYear, setSelectedYear] = useState<number>(2014);
-  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const [isPanelOpen, setIsPanelOpen] = useState(true);
   const [provinceData, setProvinceData] = useState<any | null>(null);
 
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [selectedOption, setSelectedOption] = useState<string | null>("carryingCapacity");
 
   // Fetch data for the selected province
   const loadProvinceData = async (provinceName: string) => {
@@ -138,7 +165,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
   return (
     <div>
       {/* Toggle SidePanel Button */}
-      <Button onClick={handlePanelToggle} label="Toggle SidePanel" />
+      {/* <Button onClick={handlePanelToggle} label="Toggle SidePanel" /> */}
 
       {/* Persistent Drawer */}
       <Drawer
@@ -152,6 +179,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
             maxWidth: "400px",
             boxSizing: "border-box",
             p: 2,
+            paddingTop: "20px",
             display: "flex",
             flexDirection: "column",
           },

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -3,7 +3,7 @@ import Button from "@/components/atoms/Button";
 import BarChart from "@/components/charts/barchart";
 import { Box, Drawer, Divider } from "@mui/material";
 import RadioButton from "@/components/atoms/RadioButton";
-import Slide from "@/components/atoms/Slide";
+import Slide from "@/components/molecules/Slide";
 import Toggle from "@/components/atoms/Toggle";
 
 interface SidePanelProps {
@@ -32,6 +32,7 @@ interface SidePanelProps {
   setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
   selectedOption: string | "carryingCapacity";
   setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
+  yearOptions: string[];
 }
 const SidePanel: React.FC<SidePanelProps> = ({
   provinceName,
@@ -59,6 +60,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
   setGrazingRange,
   selectedOption,
   setSelectedOption,
+  yearOptions,
 }) => {
   const [provinceData, setProvinceData] = useState<any | null>(null);
 
@@ -117,7 +119,6 @@ const SidePanel: React.FC<SidePanelProps> = ({
 
   const handlePanelToggle = () => {
     setIsPanelOpen(!isPanelOpen);
-    // setSelectedYear(2014);
     if (!isPanelOpen) {
       setProvinceData(null); // Clear province data when closing the panel
     }
@@ -132,20 +133,19 @@ const SidePanel: React.FC<SidePanelProps> = ({
 
   const handleOptionChange = (option: string) => {
     setSelectedOption(option);
-    // Reset states when changing the option
     if (option === "carryingCapacity") {
-      setCarryingCapacity(true);   // Activate Carrying Capacity
-      setNdviSelect(false);        // Deactivate NDVI
+      setCarryingCapacity(true);
+      setNdviSelect(false);
       setShowPositiveCells(false);
       setShowZeroCells(false);
       setShowNegativeCells(false);
-      setShowBelowCells(false);    // Reset Carrying Capacity states
+      setShowBelowCells(false);
       setShowAtCapCells(false);
       setShowAboveCells(false);
     } else if (option === "zScore") {
-      setCarryingCapacity(false);  // Deactivate Carrying Capacity
-      setNdviSelect(true);         // Activate NDVI
-      setShowBelowCells(false);    // Reset NDVI states
+      setCarryingCapacity(false);
+      setNdviSelect(true);
+      setShowBelowCells(false);
       setShowAtCapCells(false);
       setShowAboveCells(false);
       setShowNegativeCells(false);
@@ -247,6 +247,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
                 onChange={handleYearSlider}
                 min={2002}
                 max={2014}
+                options={yearOptions}
               />
               <h2>Grazing Range</h2>
               <Toggle initialChecked={grazingRange} onChange={(checked) => setGrazingRange(checked)} />

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -30,6 +30,8 @@ interface SidePanelProps {
   setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
   grazingRange: boolean | false;
   setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedOption: string | "carryingCapacity";
+  setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
 }
 const SidePanel: React.FC<SidePanelProps> = ({
   provinceName,
@@ -55,11 +57,12 @@ const SidePanel: React.FC<SidePanelProps> = ({
   setSelectedYear,
   grazingRange,
   setGrazingRange,
+  selectedOption,
+  setSelectedOption,
 }) => {
   const [provinceData, setProvinceData] = useState<any | null>(null);
 
   const livestockTypes = ["Cattle", "Horse", "Goat", "Camel", "Sheep"];
-  const [selectedOption, setSelectedOption] = useState<string | null>("carryingCapacity");
 
   // Fetch data for the selected province
   const loadProvinceData = async (provinceName: string) => {
@@ -127,9 +130,31 @@ const SidePanel: React.FC<SidePanelProps> = ({
     setProvinceData(null);
   };
 
-  const handleOptionChange = (value: string) => {
-    setSelectedOption(value);
+  const handleOptionChange = (option: string) => {
+    setSelectedOption(option);
+    // Reset states when changing the option
+    if (option === "carryingCapacity") {
+      setCarryingCapacity(true);   // Activate Carrying Capacity
+      setNdviSelect(false);        // Deactivate NDVI
+      setShowPositiveCells(false);
+      setShowZeroCells(false);
+      setShowNegativeCells(false);
+      setShowBelowCells(false);    // Reset Carrying Capacity states
+      setShowAtCapCells(false);
+      setShowAboveCells(false);
+    } else if (option === "zScore") {
+      setCarryingCapacity(false);  // Deactivate Carrying Capacity
+      setNdviSelect(true);         // Activate NDVI
+      setShowBelowCells(false);    // Reset NDVI states
+      setShowAtCapCells(false);
+      setShowAboveCells(false);
+      setShowNegativeCells(false);
+      setShowPositiveCells(false);
+      setShowZeroCells(false);
+    }
   };
+
+  
 
   const options = [
     {

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -26,13 +26,36 @@ interface TopPanelProps {
   setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
   grazingRange: boolean | null;
   setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedOption: string | "carryingCapacity";
+  setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, isPanelOpen, setPanelOpen, carryingCapacity, showBelowCells, 
-  showAtCapCells, showAboveCells, setCarryingCapacity, setShowBelowCells, setShowAtCapCells, 
-  setShowAboveCells, ndviSelect, showPositiveCells, showZeroCells, showNegativeCells, setNdviSelect,
-  setShowPositiveCells, setShowZeroCells, setShowNegativeCells, selectedYear, setSelectedYear,
-  grazingRange, setGrazingRange }) => {
+const TopPanel: React.FC<TopPanelProps> = ({
+  onProvinceSelect,
+  isPanelOpen,
+  setPanelOpen,
+  carryingCapacity,
+  showBelowCells, 
+  showAtCapCells,
+  showAboveCells,
+  setCarryingCapacity,
+  setShowBelowCells,
+  setShowAtCapCells, 
+  setShowAboveCells,
+  ndviSelect,
+  showPositiveCells,
+  showZeroCells,
+  showNegativeCells,
+  setNdviSelect,
+  setShowPositiveCells,
+  setShowZeroCells,
+  setShowNegativeCells,
+  selectedYear,
+  setSelectedYear,
+  grazingRange,
+  setGrazingRange,
+  selectedOption,
+  setSelectedOption }) => {
   const uniqueData = [
     "Dornod",
     "Bayan-Ölgiy",
@@ -194,9 +217,30 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, isPanelOpen, setP
           }
           {/* Toggle carrying capacity */}
           {!isPanelOpen && (<Button
-            onClick={() => {setCarryingCapacity((prev) => !prev); setNdviSelect((prev) => !prev); setShowAboveCells(false);
-              setShowAtCapCells(false); setShowBelowCells(false); setShowNegativeCells(false); setShowPositiveCells(false);
-              setShowZeroCells(false);}}
+            onClick={() => {    if (carryingCapacity) {
+              // If we're currently on Carrying Capacity, switch to NDVI
+              setCarryingCapacity(false);
+              setNdviSelect(true);
+              setSelectedOption("zScore");
+              // Reset NDVI-related states
+              setShowAboveCells(false);
+              setShowAtCapCells(false);
+              setShowBelowCells(false);
+              setShowNegativeCells(false);
+              setShowPositiveCells(false);
+              setShowZeroCells(false);
+            } else {
+              setCarryingCapacity(true);
+              setNdviSelect(false);
+              setSelectedOption("carryingCapacity");
+              setShowBelowCells(false);
+              setShowAtCapCells(false);
+              setShowAboveCells(false);
+              setShowNegativeCells(false);
+              setShowPositiveCells(false);
+              setShowZeroCells(false);
+            }
+          }}
             label={carryingCapacity ? "Switch to NDVI" : "Switch to Carrying Capacity"}
             sx={{ marginBottom: 2 }}
           />)

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -146,6 +146,12 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, isPanelOpen, setP
             sx={{ width: "200px" }}/>
 
           )}
+          {!isPanelOpen && (
+            <Button
+              onClick={() => setGrazingRange((prev) => !prev)}
+              label="Grazing Range"
+              sx={{
+                backgroundColor: grazingRange ? 'green' : 'grey'}}/>)}
           {
           !isPanelOpen && carryingCapacity && (
             <><Button

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -163,7 +163,7 @@ const TopPanel: React.FC<TopPanelProps> = ({
   return (
     <div>
       <div style={{ display: "flex", gap: "10px" }}>
-        <div style={{ marginTop: "10px" }}>
+        <div>
           <SearchBar
             uniqueData={uniqueData}
             onValueSelect={handleValueSelect}
@@ -176,7 +176,7 @@ const TopPanel: React.FC<TopPanelProps> = ({
             options={yearOptions}
             value={selectedYear.toString()}
             onChange={(val) => setSelectedYear(val)}
-            sx={{ width: "200px" }}/>
+            sx={{ width: "160px" }}/>
 
           )}
           {!isPanelOpen && (

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -3,6 +3,8 @@ import Button from "@/components/atoms/Button";
 import Dropdown from "../atoms/DropDown";
 import { useRouter } from "next/router";
 import HomeIcon from "@mui/icons-material/Home";
+import { Avatar } from "@mui/material";
+import PersonIcon from "@mui/icons-material/Person";
 
 interface TopPanelProps {
   onProvinceSelect: (provinceName: { value: string }) => void;
@@ -259,6 +261,11 @@ const TopPanel: React.FC<TopPanelProps> = ({
           sx={{
             backgroundColor: 'grey' }}
           startIcon={<HomeIcon/>}/>
+        <Button
+          onClick={() => {}} // Placeholder for future routing
+          sx={{
+            backgroundColor: "transparent" }}
+          startIcon={<Avatar><PersonIcon/></Avatar>}/>
       </div>
     </div>
   );

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import HomeIcon from "@mui/icons-material/Home";
 import { Avatar } from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 
 interface TopPanelProps {
   onProvinceSelect: (provinceName: { value: string }) => void;
@@ -33,6 +34,7 @@ interface TopPanelProps {
   selectedOption: string | "carryingCapacity";
   setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
   yearOptions: string[];
+  setDisplayName: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const TopPanel: React.FC<TopPanelProps> = ({
@@ -61,37 +63,44 @@ const TopPanel: React.FC<TopPanelProps> = ({
   setGrazingRange,
   selectedOption,
   setSelectedOption,
-  yearOptions }) => {
-  const uniqueData = [
-    "Dornod",
-    "Bayan-Ölgiy",
-    "Hovd",
-    "Sühbaatar",
-    "Dornogovi",
-    "Govi-Altay",
-    "Bayanhongor",
-    "Ömnögovi",
-    "Hövsgöl",
-    "Bulgan",
-    "Uvs",
-    "Selenge",
-    "Dzavhan",
-    "Hentiy",
-    "Darhan-Uul",
-    "Töv",
-    "Arhangay",
-    "Orhon",
-    "Dundgovi",
-    "Övörhangay",
-    "Govĭ-Sümber",
-    "Ulaanbaatar", // Capital city (not a province but included for reference)
-  ];
+  yearOptions,
+  setDisplayName }) => {
 
   const router = useRouter();
 
   const navigateTo = (path: string) => {
     router.push(path);
   };
+
+  const specialCharsToEnglishMap = {
+    'Ö': 'U', 'ö': 'u',
+    'ü': 'u', 'ĭ': 'i',
+    'Ё': 'yo', 'ё': 'yo',
+  };
+
+  const uniqueData = [
+    "Dornod",
+    "Bayan-Ölgii",
+    "Khovd",
+    "Sükhbaatar",
+    "Dornogovi",
+    "Govi-Altai",
+    "Bayankhongor",
+    "Ömnögovi",
+    "Khövsgöl",
+    "Bulgan",
+    "Uvs",
+    "Selenge",
+    "Zavkhan",
+    "Khentii",
+    "Darkhan-Uul",
+    "Töv",
+    "Arkhangai",
+    "Orkhon",
+    "Dundgovi",
+    "Övörkhangai",
+    "Govisümber",
+  ];
 
   const toggleCellState = (cellType: string) => {
     switch (cellType) {
@@ -155,9 +164,24 @@ const TopPanel: React.FC<TopPanelProps> = ({
     return {}; // Default case (should never be reached if above logic is correct)
   };
 
+  const transformString = (name: string): string => {
+    let transformedName = '';
   
-  const handleValueSelect = (provinceData: { value: string }) => {
-    onProvinceSelect(provinceData); // Pass the value up to MPP
+    for (let char of name) {
+      // Log each character and its transformed value
+      const transformedChar = specialCharsToEnglishMap[char] || char;
+      transformedName += transformedChar;
+    }
+  
+    return transformedName;  // Return the transformed string
+  };
+  
+  const handleValueSelect = async (provinceData: { value: string }) => {
+      const transformedName = transformString(provinceData.name);
+      console.log(transformedName);
+      console.log(provinceData);
+      onProvinceSelect({name: transformedName});
+      setDisplayName(provinceData);
   };
 
   return (
@@ -189,7 +213,7 @@ const TopPanel: React.FC<TopPanelProps> = ({
           !isPanelOpen && carryingCapacity && (
             <><Button
                 onClick={() => toggleCellState("below")}
-                label="Below Cells"
+                label="Below"
                 sx={getButtonColor("below")}
                 disabled={!carryingCapacity} // Disable if carryingCapacity is false
               /><Button
@@ -199,7 +223,7 @@ const TopPanel: React.FC<TopPanelProps> = ({
                   disabled={!carryingCapacity} // Disable if carryingCapacity is false
                 /><Button
                   onClick={() => toggleCellState("above")}
-                  label="Above Cells"
+                  label="Above"
                   sx={getButtonColor("above")}
                   disabled={!carryingCapacity} // Disable if carryingCapacity is false
                 /></>
@@ -253,6 +277,7 @@ const TopPanel: React.FC<TopPanelProps> = ({
           }}
             label={carryingCapacity ? "Switch to NDVI" : "Switch to Carrying Capacity"}
             sx={{ marginBottom: 2 }}
+            startIcon={<SwapHorizIcon/>}
           />)
             }
         </div>

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -1,9 +1,35 @@
 import SearchBar from "@/components/molecules/SearchBar";
+import Button from "@/components/atoms/Button";
 
 interface TopPanelProps {
   onProvinceSelect: (provinceName: { value: string }) => void;
+  carryingCapacity: boolean | null;
+  showBelowCells: boolean | null;
+  showAtCapCells: boolean | null;
+  showAboveCells: boolean | null;
+  setCarryingCapacity: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowBelowCells: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowAtCapCells: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowAboveCells: React.Dispatch<React.SetStateAction<boolean>>;
+  ndviSelect: boolean | null;
+  showPositiveCells: boolean | null;
+  showZeroCells: boolean | null;
+  showNegativeCells: boolean | null;
+  setNdviSelect: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowPositiveCells: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowZeroCells: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowNegativeCells: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedYear: number | 2014;
+  setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
+  grazingRange: boolean | null;
+  setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
 }
-const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect }) => {
+
+const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, carryingCapacity, showBelowCells, 
+  showAtCapCells, showAboveCells, setCarryingCapacity, setShowBelowCells, setShowAtCapCells, 
+  setShowAboveCells, ndviSelect, showPositiveCells, showZeroCells, showNegativeCells, setNdviSelect,
+  setShowPositiveCells, setShowZeroCells, setShowNegativeCells, selectedYear, setSelectedYear,
+  grazingRange, setGrazingRange }) => {
   const uniqueData = [
     "Dornod",
     "Bayan-Ölgiy",
@@ -29,17 +55,130 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect }) => {
     "Ulaanbaatar", // Capital city (not a province but included for reference)
   ];
 
+  const toggleCellState = (cellType: string) => {
+    switch (cellType) {
+      case "below":
+        setShowBelowCells((prev) => !prev);
+        break;
+      case "atCap":
+        setShowAtCapCells((prev) => !prev);
+        break;
+      case "above":
+        setShowAboveCells((prev) => !prev);
+        break;
+      case "positive":
+        setShowPositiveCells((prev) => !prev);
+        break;
+      case "zero":
+        setShowZeroCells((prev) => !prev);
+        break;
+      case "negative":
+        setShowNegativeCells((prev) => !prev);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const getButtonColor = (cellType: string) => {
+    // Disable if neither carryingCapacity nor ndviSelect is true
+    if (!carryingCapacity && !ndviSelect) {
+      return { backgroundColor: "gray" }; // Disable if neither are selected
+    }
+  
+    // If carryingCapacity is true, handle colors for "below", "atCap", "above" cells
+    if (carryingCapacity) {
+      switch (cellType) {
+        case "below":
+          return { backgroundColor: showBelowCells ? "green" : "grey" }; // Green for "below" cells if active
+        case "atCap":
+          return { backgroundColor: showAtCapCells ? "#C6BF31" : "grey" }; // Yellow for "atCap" cells if active
+        case "above":
+          return { backgroundColor: showAboveCells ? "red" : "grey" }; // Red for "above" cells if active
+        default:
+          return {};
+      }
+    }
+  
+    // If ndviSelect is true, handle colors for "positive", "zero", "negative" cells
+    if (ndviSelect) {
+      switch (cellType) {
+        case "positive":
+          return { backgroundColor: showPositiveCells ? "teal" : "grey" }; // Teal for "positive" cells if active
+        case "zero":
+          return { backgroundColor: showZeroCells ? "darkblue" : "grey" }; // Dark Blue for "zero" cells if active
+        case "negative":
+          return { backgroundColor: showNegativeCells ? "purple" : "grey" }; // Purple for "negative" cells if active
+        default:
+          return {};
+      }
+    }
+  
+    return {}; // Default case (should never be reached if above logic is correct)
+  };
+  
+  
   const handleValueSelect = (provinceData: { value: string }) => {
     onProvinceSelect(provinceData); // Pass the value up to MPP
   };
+
   return (
     <div>
-      <h1>Monitoring Platform</h1>
       <div style={{ display: "flex", gap: "10px" }}>
-        <div style={{ marginTop: "60px" }}>
+        <div style={{ marginTop: "10px" }}>
           <SearchBar
             uniqueData={uniqueData}
             onValueSelect={handleValueSelect}
+          />
+        </div>
+        <div>
+          {
+          carryingCapacity && (
+            <><Button
+                onClick={() => toggleCellState("below")}
+                label="Below Cells"
+                sx={getButtonColor("below")}
+                disabled={!carryingCapacity} // Disable if carryingCapacity is false
+              /><Button
+                  onClick={() => toggleCellState("atCap")}
+                  label="At Cap Cells"
+                  sx={getButtonColor("atCap")}
+                  disabled={!carryingCapacity} // Disable if carryingCapacity is false
+                /><Button
+                  onClick={() => toggleCellState("above")}
+                  label="Above Cells"
+                  sx={getButtonColor("above")}
+                  disabled={!carryingCapacity} // Disable if carryingCapacity is false
+                /></>
+          )
+          }
+          {
+          ndviSelect && (
+            <><Button
+                onClick={() => toggleCellState("positive")}
+                label="Positive"
+                sx={getButtonColor("positive")}
+                disabled={!ndviSelect} // Disable if carryingCapacity is false
+              /><Button
+                  onClick={() => toggleCellState("zero")}
+                  label="Zero"
+                  sx={getButtonColor("zero")}
+                  disabled={!ndviSelect} // Disable if carryingCapacity is false
+                /><Button
+                  onClick={() => toggleCellState("negative")}
+                  label="Negative"
+                  sx={getButtonColor("negative")}
+                  disabled={!ndviSelect} // Disable if carryingCapacity is false
+                /></>
+          )
+          }
+          {/* Toggle carrying capacity */}
+          <Button
+            onClick={() => {setCarryingCapacity((prev) => !prev); setNdviSelect((prev) => !prev); setShowAboveCells(false);
+              setShowAtCapCells(false); setShowBelowCells(false); setShowNegativeCells(false); setShowPositiveCells(false);
+              setShowZeroCells(false);}}
+            label={carryingCapacity ? "Switch to NDVI" : "Switch to Carrying Capacity"}
+            sx={{ marginBottom: 2 }}
           />
         </div>
       </div>

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -1,8 +1,11 @@
 import SearchBar from "@/components/molecules/SearchBar";
 import Button from "@/components/atoms/Button";
+import Dropdown from "../atoms/DropDown";
 
 interface TopPanelProps {
   onProvinceSelect: (provinceName: { value: string }) => void;
+  isPanelOpen: boolean | null;
+  setPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
   carryingCapacity: boolean | null;
   showBelowCells: boolean | null;
   showAtCapCells: boolean | null;
@@ -25,7 +28,7 @@ interface TopPanelProps {
   setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, carryingCapacity, showBelowCells, 
+const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, isPanelOpen, setPanelOpen, carryingCapacity, showBelowCells, 
   showAtCapCells, showAboveCells, setCarryingCapacity, setShowBelowCells, setShowAtCapCells, 
   setShowAboveCells, ndviSelect, showPositiveCells, showZeroCells, showNegativeCells, setNdviSelect,
   setShowPositiveCells, setShowZeroCells, setShowNegativeCells, selectedYear, setSelectedYear,
@@ -116,7 +119,9 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, carryingCapacity,
   
     return {}; // Default case (should never be reached if above logic is correct)
   };
-  
+
+  const yearOptions = Array.from({ length: 2014 - 2002 + 1 }, (_, index) => (2002 + index).toString());
+
   
   const handleValueSelect = (provinceData: { value: string }) => {
     onProvinceSelect(provinceData); // Pass the value up to MPP
@@ -131,9 +136,18 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, carryingCapacity,
             onValueSelect={handleValueSelect}
           />
         </div>
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '20px', width: '100%' }}>
+          {!isPanelOpen && (
+          <Dropdown
+            label="Select Year"
+            options={yearOptions}
+            value={selectedYear}
+            onChange={(val) => setSelectedYear(val)}
+            sx={{ width: "200px" }}/>
+
+          )}
           {
-          carryingCapacity && (
+          !isPanelOpen && carryingCapacity && (
             <><Button
                 onClick={() => toggleCellState("below")}
                 label="Below Cells"
@@ -141,7 +155,7 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, carryingCapacity,
                 disabled={!carryingCapacity} // Disable if carryingCapacity is false
               /><Button
                   onClick={() => toggleCellState("atCap")}
-                  label="At Cap Cells"
+                  label="At Capacity"
                   sx={getButtonColor("atCap")}
                   disabled={!carryingCapacity} // Disable if carryingCapacity is false
                 /><Button
@@ -153,7 +167,7 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, carryingCapacity,
           )
           }
           {
-          ndviSelect && (
+          !isPanelOpen && ndviSelect && (
             <><Button
                 onClick={() => toggleCellState("positive")}
                 label="Positive"
@@ -173,13 +187,14 @@ const TopPanel: React.FC<TopPanelProps> = ({ onProvinceSelect, carryingCapacity,
           )
           }
           {/* Toggle carrying capacity */}
-          <Button
+          {!isPanelOpen && (<Button
             onClick={() => {setCarryingCapacity((prev) => !prev); setNdviSelect((prev) => !prev); setShowAboveCells(false);
               setShowAtCapCells(false); setShowBelowCells(false); setShowNegativeCells(false); setShowPositiveCells(false);
               setShowZeroCells(false);}}
             label={carryingCapacity ? "Switch to NDVI" : "Switch to Carrying Capacity"}
             sx={{ marginBottom: 2 }}
-          />
+          />)
+            }
         </div>
       </div>
     </div>

--- a/frontend/src/components/organisms/TopPanel.tsx
+++ b/frontend/src/components/organisms/TopPanel.tsx
@@ -1,6 +1,8 @@
 import SearchBar from "@/components/molecules/SearchBar";
 import Button from "@/components/atoms/Button";
 import Dropdown from "../atoms/DropDown";
+import { useRouter } from "next/router";
+import HomeIcon from "@mui/icons-material/Home";
 
 interface TopPanelProps {
   onProvinceSelect: (provinceName: { value: string }) => void;
@@ -28,6 +30,7 @@ interface TopPanelProps {
   setGrazingRange: React.Dispatch<React.SetStateAction<boolean>>;
   selectedOption: string | "carryingCapacity";
   setSelectedOption: React.Dispatch<React.SetStateAction<string>>;
+  yearOptions: string[];
 }
 
 const TopPanel: React.FC<TopPanelProps> = ({
@@ -55,7 +58,8 @@ const TopPanel: React.FC<TopPanelProps> = ({
   grazingRange,
   setGrazingRange,
   selectedOption,
-  setSelectedOption }) => {
+  setSelectedOption,
+  yearOptions }) => {
   const uniqueData = [
     "Dornod",
     "Bayan-Ölgiy",
@@ -80,6 +84,12 @@ const TopPanel: React.FC<TopPanelProps> = ({
     "Govĭ-Sümber",
     "Ulaanbaatar", // Capital city (not a province but included for reference)
   ];
+
+  const router = useRouter();
+
+  const navigateTo = (path: string) => {
+    router.push(path);
+  };
 
   const toggleCellState = (cellType: string) => {
     switch (cellType) {
@@ -143,8 +153,6 @@ const TopPanel: React.FC<TopPanelProps> = ({
     return {}; // Default case (should never be reached if above logic is correct)
   };
 
-  const yearOptions = Array.from({ length: 2014 - 2002 + 1 }, (_, index) => (2002 + index).toString());
-
   
   const handleValueSelect = (provinceData: { value: string }) => {
     onProvinceSelect(provinceData); // Pass the value up to MPP
@@ -164,7 +172,7 @@ const TopPanel: React.FC<TopPanelProps> = ({
           <Dropdown
             label="Select Year"
             options={yearOptions}
-            value={selectedYear}
+            value={selectedYear.toString()}
             onChange={(val) => setSelectedYear(val)}
             sx={{ width: "200px" }}/>
 
@@ -246,6 +254,11 @@ const TopPanel: React.FC<TopPanelProps> = ({
           />)
             }
         </div>
+        <Button
+          onClick={() => navigateTo("/landing")}
+          sx={{
+            backgroundColor: 'grey' }}
+          startIcon={<HomeIcon/>}/>
       </div>
     </div>
   );

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -3,38 +3,97 @@ import Map from "../components/Map";
 import TopPanel from "../components/organisms/TopPanel";
 import SidePanel from "../components/organisms/SidePanel";
 const MonitoringPlatform = () => {
+
   const [selectedProvince, setSelectedProvince] = useState<string | null>(null);
+
+  // Associated with Carrying Capacity
+  const [carryingCapacity, setCarryingCapacity]= useState(true);
   const [showBelowCells, setShowBelowCells] = useState(false);
   const [showAtCapCells, setShowAtCapCells] = useState(false);
   const [showAboveCells, setShowAboveCells] = useState(false);
+
+  //Associated with Z-Score NDVI
+  const [ndviSelect, setNdviSelect]= useState(false);
+  const [showPositiveCells, setShowPositiveCells] = useState(false);
+  const [showZeroCells, setShowZeroCells] = useState(false);
+  const [showNegativeCells, setShowNegativeCells] = useState(false);
+
+  const [selectedYear, setSelectedYear] = useState<number>(2014);
+
+  const [grazingRange, setGrazingRange] = useState(false);
 
   const handleProvinceSelect = (provinceName: string) => {
     setSelectedProvince(provinceName);
   };
   console.log(setSelectedProvince);
-
+  // interface for SidePanel
+  // fetch coord data for all provinces
   return (
     <>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <div style={{ height: '35px', padding: '30px', zIndex: 1 }}>
       {/* Top Panel */}
-      <TopPanel onProvinceSelect={handleProvinceSelect} />
-      {/* Map Component */}
-      <SidePanel
-        provinceName={selectedProvince}
-        showBelowCells={showBelowCells}
-        setShowBelowCells={setShowBelowCells}
-        showAtCapCells={showAtCapCells}
-        setShowAtCapCells={setShowAtCapCells}
-        showAboveCells={showAboveCells}
-        setShowAboveCells={setShowAboveCells}
-      />
-      <Map
+      <TopPanel 
         onProvinceSelect={handleProvinceSelect}
-        showAboveCells={showAboveCells}
-        showAtCapCells={showAtCapCells}
+        carryingCapacity={carryingCapacity}
         showBelowCells={showBelowCells}
+        showAtCapCells={showAtCapCells}
+        showAboveCells={showAboveCells}
+        setCarryingCapacity={setCarryingCapacity}
+        setShowBelowCells={setShowBelowCells}
+        setShowAtCapCells={setShowAtCapCells}
+        setShowAboveCells={setShowAboveCells}
+        ndviSelect={ndviSelect}
+        showPositiveCells={showPositiveCells}
+        showZeroCells={showZeroCells}
+        showNegativeCells={showNegativeCells}
+        setNdviSelect={setNdviSelect}
+        setShowPositiveCells={setShowPositiveCells}
+        setShowZeroCells={setShowZeroCells}
+        setShowNegativeCells={setShowNegativeCells}
+        selectedYear={selectedYear}
+        setSelectedYear={setSelectedYear}
+        grazingRange={grazingRange}
+        setGrazingRange={setGrazingRange}
       />
+      </div>
+      <div>
+        <SidePanel // fetch for specific info
+          provinceName={selectedProvince}
+          carryingCapacity={carryingCapacity}
+          setCarryingCapacity={setCarryingCapacity}
+          showBelowCells={showBelowCells}
+          setShowBelowCells={setShowBelowCells}
+          showAtCapCells={showAtCapCells}
+          setShowAtCapCells={setShowAtCapCells}
+          showAboveCells={showAboveCells}
+          setShowAboveCells={setShowAboveCells}
+          ndviSelect={ndviSelect}
+          setNdviSelect={setNdviSelect}
+          showPositiveCells={showPositiveCells}
+          setShowPositiveCells={setShowPositiveCells}
+          showZeroCells={showZeroCells}
+          setShowZeroCells={setShowZeroCells}
+          showNegativeCells={showNegativeCells}
+          setShowNegativeCells={setShowNegativeCells}
+          selectedYear={selectedYear}
+          setSelectedYear={setSelectedYear}
+          grazingRange={grazingRange}
+          setGrazingRange={setGrazingRange}
+        />
+      </div>
+        <Map // fetches all coordinates Province/Counties/Cells
+          onProvinceSelect={handleProvinceSelect}
+          showAboveCells={showAboveCells}
+          showAtCapCells={showAtCapCells}
+          showBelowCells={showBelowCells}
+        />
+    </div>
     </>
   );
 };
 
 export default MonitoringPlatform;
+// Use Case: when a user looks up a sopecifc province
+//1. Click - Map --> provinceName as Prop and query that province
+//2. Search - Top Panel

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -5,6 +5,7 @@ import SidePanel from "../components/organisms/SidePanel";
 const MonitoringPlatform = () => {
 
   const [selectedProvince, setSelectedProvince] = useState<string | null>(null);
+  const [isPanelOpen, setIsPanelOpen] = useState(true);
 
   // Associated with Carrying Capacity
   const [carryingCapacity, setCarryingCapacity]= useState(true);
@@ -25,7 +26,51 @@ const MonitoringPlatform = () => {
   const handleProvinceSelect = (provinceName: string) => {
     setSelectedProvince(provinceName);
   };
-  console.log(setSelectedProvince);
+
+  const handleIsPanelOpenChange = (value) => {
+    setIsPanelOpen(value);
+  };
+
+  const handleCarryingCapacityChange = (value) => {
+    setCarryingCapacity(value);
+  };
+
+  const handleShowBelowCellsChange = (value) => {
+    setShowBelowCells(value);
+  };
+
+  const handleShowAtCapCellsChange = (value) => {
+    setShowAtCapCells(value);
+  };
+
+  const handleShowAboveCellsChange = (value) => {
+    setShowAboveCells(value);
+  };
+
+  const handleNdviSelectChange = (value) => {
+    setNdviSelect(value);
+  };
+
+  const handleShowPositiveCellsChange = (value) => {
+    setShowPositiveCells(value);
+  };
+
+  const handleShowZeroCellsChange = (value) => {
+    setShowZeroCells(value);
+  };
+
+  const handleShowNegativeCellsChange = (value) => {
+    setShowNegativeCells(value);
+  };
+
+  const handleSelectedYearChange = (value) => {
+    setSelectedYear(value);
+  };
+
+  const handleGrazingRangeChange = (value) => {
+    setGrazingRange(value);
+  };
+
   // interface for SidePanel
   // fetch coord data for all provinces
   return (
@@ -35,51 +80,55 @@ const MonitoringPlatform = () => {
       {/* Top Panel */}
       <TopPanel 
         onProvinceSelect={handleProvinceSelect}
+        isPanelOpen={isPanelOpen}
+        setIsPanelOpen={handleIsPanelOpenChange}
         carryingCapacity={carryingCapacity}
         showBelowCells={showBelowCells}
         showAtCapCells={showAtCapCells}
         showAboveCells={showAboveCells}
-        setCarryingCapacity={setCarryingCapacity}
-        setShowBelowCells={setShowBelowCells}
-        setShowAtCapCells={setShowAtCapCells}
-        setShowAboveCells={setShowAboveCells}
+        setCarryingCapacity={handleCarryingCapacityChange}
+        setShowBelowCells={handleShowBelowCellsChange}
+        setShowAtCapCells={handleShowAtCapCellsChange}
+        setShowAboveCells={handleShowAboveCellsChange}
         ndviSelect={ndviSelect}
         showPositiveCells={showPositiveCells}
         showZeroCells={showZeroCells}
         showNegativeCells={showNegativeCells}
-        setNdviSelect={setNdviSelect}
-        setShowPositiveCells={setShowPositiveCells}
-        setShowZeroCells={setShowZeroCells}
-        setShowNegativeCells={setShowNegativeCells}
+        setNdviSelect={handleNdviSelectChange}
+        setShowPositiveCells={handleShowPositiveCellsChange}
+        setShowZeroCells={handleShowZeroCellsChange}
+        setShowNegativeCells={handleShowNegativeCellsChange}
         selectedYear={selectedYear}
-        setSelectedYear={setSelectedYear}
+        setSelectedYear={handleSelectedYearChange}
         grazingRange={grazingRange}
-        setGrazingRange={setGrazingRange}
+        setGrazingRange={handleGrazingRangeChange}
       />
       </div>
       <div>
         <SidePanel // fetch for specific info
           provinceName={selectedProvince}
+          isPanelOpen={isPanelOpen}
+          setIsPanelOpen={handleIsPanelOpenChange}
           carryingCapacity={carryingCapacity}
-          setCarryingCapacity={setCarryingCapacity}
+          setCarryingCapacity={handleCarryingCapacityChange}
           showBelowCells={showBelowCells}
-          setShowBelowCells={setShowBelowCells}
+          setShowBelowCells={handleShowBelowCellsChange}
           showAtCapCells={showAtCapCells}
-          setShowAtCapCells={setShowAtCapCells}
+          setShowAtCapCells={handleShowAtCapCellsChange}
           showAboveCells={showAboveCells}
-          setShowAboveCells={setShowAboveCells}
+          setShowAboveCells={handleShowAboveCellsChange}
           ndviSelect={ndviSelect}
-          setNdviSelect={setNdviSelect}
+          setNdviSelect={handleNdviSelectChange}
           showPositiveCells={showPositiveCells}
-          setShowPositiveCells={setShowPositiveCells}
+          setShowPositiveCells={handleShowPositiveCellsChange}
           showZeroCells={showZeroCells}
-          setShowZeroCells={setShowZeroCells}
+          setShowZeroCells={handleShowZeroCellsChange}
           showNegativeCells={showNegativeCells}
-          setShowNegativeCells={setShowNegativeCells}
+          setShowNegativeCells={handleShowNegativeCellsChange}
           selectedYear={selectedYear}
-          setSelectedYear={setSelectedYear}
+          setSelectedYear={handleSelectedYearChange}
           grazingRange={grazingRange}
-          setGrazingRange={setGrazingRange}
+          setGrazingRange={handleGrazingRangeChange}
         />
       </div>
         <Map // fetches all coordinates Province/Counties/Cells

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -23,6 +23,8 @@ const MonitoringPlatform = () => {
 
   const [grazingRange, setGrazingRange] = useState(false);
 
+  const [selectedOption, setSelectedOption] = useState<string>("carryingCapacity");
+
   const handleProvinceSelect = (provinceName: string) => {
     setSelectedProvince(provinceName);
   };
@@ -71,6 +73,8 @@ const MonitoringPlatform = () => {
     setGrazingRange(value);
   };
 
+  console.log("ndvi", ndviSelect);
+  console.log("cars", carryingCapacity);
   // interface for SidePanel
   // fetch coord data for all provinces
   return (
@@ -102,6 +106,8 @@ const MonitoringPlatform = () => {
         setSelectedYear={handleSelectedYearChange}
         grazingRange={grazingRange}
         setGrazingRange={handleGrazingRangeChange}
+        selectedOption={selectedOption}
+        setSelectedOption={setSelectedOption}
       />
       </div>
       <div>
@@ -129,6 +135,8 @@ const MonitoringPlatform = () => {
           setSelectedYear={handleSelectedYearChange}
           grazingRange={grazingRange}
           setGrazingRange={handleGrazingRangeChange}
+          selectedOption={selectedOption}
+          setSelectedOption={setSelectedOption}
         />
       </div>
         <Map // fetches all coordinates Province/Counties/Cells

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -22,8 +22,10 @@ const MonitoringPlatform = () => {
   const [selectedYear, setSelectedYear] = useState<number>(2014);
   const [grazingRange, setGrazingRange] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string>("carryingCapacity");
+  const [displayName, setDisplayName] = useState<string>("");
 
   const yearOptions = Array.from({ length: 2014 - 2002 + 1 }, (_, index) => (2002 + index).toString());
+
 
 
   const handleProvinceSelect = (provinceName: string) => {
@@ -107,6 +109,7 @@ const MonitoringPlatform = () => {
         selectedOption={selectedOption}
         setSelectedOption={setSelectedOption}
         yearOptions={yearOptions}
+        setDisplayName={setDisplayName}
       />
       </div>
       <div>
@@ -137,6 +140,7 @@ const MonitoringPlatform = () => {
           selectedOption={selectedOption}
           setSelectedOption={setSelectedOption}
           yearOptions={yearOptions}
+          displayName={displayName}
         />
       </div>
         <Map // fetches all coordinates Province/Counties/Cells

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -20,10 +20,11 @@ const MonitoringPlatform = () => {
   const [showNegativeCells, setShowNegativeCells] = useState(false);
 
   const [selectedYear, setSelectedYear] = useState<number>(2014);
-
   const [grazingRange, setGrazingRange] = useState(false);
-
   const [selectedOption, setSelectedOption] = useState<string>("carryingCapacity");
+
+  const yearOptions = Array.from({ length: 2014 - 2002 + 1 }, (_, index) => (2002 + index).toString());
+
 
   const handleProvinceSelect = (provinceName: string) => {
     setSelectedProvince(provinceName);
@@ -73,10 +74,7 @@ const MonitoringPlatform = () => {
     setGrazingRange(value);
   };
 
-  console.log("ndvi", ndviSelect);
-  console.log("cars", carryingCapacity);
-  // interface for SidePanel
-  // fetch coord data for all provinces
+
   return (
     <>
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
@@ -108,6 +106,7 @@ const MonitoringPlatform = () => {
         setGrazingRange={handleGrazingRangeChange}
         selectedOption={selectedOption}
         setSelectedOption={setSelectedOption}
+        yearOptions={yearOptions}
       />
       </div>
       <div>
@@ -137,6 +136,7 @@ const MonitoringPlatform = () => {
           setGrazingRange={handleGrazingRangeChange}
           selectedOption={selectedOption}
           setSelectedOption={setSelectedOption}
+          yearOptions={yearOptions}
         />
       </div>
         <Map // fetches all coordinates Province/Counties/Cells


### PR DESCRIPTION
## Overview
The goal of the ticket was to finalize the creation of the top panel and ensure that the top panel was fully connected to the current side panel. Specifically, to ensure that the top panel displays the same information selected by the side panel and vice versa. On top of that, there were additional styling edits that were made to better replicate the ideal designs.

## Testing
To test the features, the changes are made on the "connect-sp-to-tp" branch. After running "npm i" and "yarn run dev", the tester can go on "http://localhost:3000/monitoring-platform" to see the addition of the top panel and the side panel. To test, the side panel should by default be open with no buttons from the top panel except for the home and profile button. If the user closes the side panel, the buttons selected should be displayed on the top panel. If none are selected, the default value is "carrying capacity" in 2014. It should be synced if the top panel is to make any changes.

## Impact
By syncing the top panel and side panel, the user can alternate through either panel to display the information the user would like to see without having to start over. This allows for the website to be more overall synced. 

## Screenshots
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/17a56639-50ce-4ee1-86cb-ddd07e7a1cf5">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6abed204-9e33-4150-91a6-ed525bffc821">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c10838e3-e6ac-4c30-a0fa-07035764e62c">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f0247781-c472-4e7c-8bc7-8b3313a0f091">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9c08c62e-910d-43b7-88ba-41ac49df606f">

## Notes
- need to change styling for home button and profile button
- need to make side panel height to be at most up to the top panel