### PR TITLE
Grazing filter

### DIFF
--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -30,7 +30,7 @@ interface CellGeometry {
   name: string;
   coordinates: number[];
   vertices: [number, number][];
-  grazing: boolean; // Add grazing boolean value
+  grazing_range: boolean; // Add grazing boolean value
 }
 
 const MAP_STYLE =
@@ -74,6 +74,7 @@ const MapComponent: React.FC = () => {
     showZeroCells,
     selectedLayerType,
     setSelectedLayerType,
+    grazingRange
   } = context;
 
   const loadCarryingCapacityCells = async () => {
@@ -98,23 +99,21 @@ const MapComponent: React.FC = () => {
         json_below_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
-          grazing: feature.grazing, // Include grazing boolean value
+          grazing_range: feature.grazing_range, // Include grazing boolean value
         }))
       );
       setAtCapCells(
         json_at_cap_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
-          grazing: feature.grazing, // Include grazing boolean value
-
+          grazing_range: feature.grazing_range,// Include grazing boolean value
         }))
       );
       setAboveCells(
         json_above_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
-          grazing: feature.grazing, // Include grazing boolean value
-
+          grazing_range: feature.grazing_range, // Include grazing boolean value
         }))
       );
     } catch (error) {
@@ -146,15 +145,14 @@ const MapComponent: React.FC = () => {
         json_negative_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
-          grazing: feature.grazing, // Include grazing boolean value
-
+          grazing_range: feature.grazing_range,  // Include grazing boolean value
         }))
       );
       setZeroCells(
         json_zero_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
-          grazing: feature.grazing, // Include grazing boolean value
+          grazing_range: feature.grazing_range,  // Include grazing boolean value
 
         }))
       );
@@ -162,8 +160,7 @@ const MapComponent: React.FC = () => {
         json_positive_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
-          grazing: feature.grazing, // Include grazing boolean value
-
+          grazing_range: feature.grazing_range,  // Include grazing boolean value
         }))
       );
     } catch (error) {
@@ -308,7 +305,9 @@ const MapComponent: React.FC = () => {
 
   const cellsBelowLayer = new ScatterplotLayer({
     id: "point-layer",
-    data: belowCells, // Point Data
+    data: !grazingRange
+    ? belowCells
+    : belowCells.filter(d => d.grazing_range == grazingRange), // Point Data
     getPosition: (d) => d.vertices,
     getRadius: 5000, // Adjust size
     getFillColor: [0, 170, 60, 200], // Red color for visibility
@@ -317,7 +316,9 @@ const MapComponent: React.FC = () => {
   
   const cellsAtCapLayer = new ScatterplotLayer({
     id: "point-layer",
-    data: atCapCells, // Point Data
+    data: !grazingRange
+    ? atCapCells
+    : atCapCells.filter(d => d.grazing_range == grazingRange), // Point Data
     getPosition: (d) => d.vertices,
     getRadius: 5000, // Adjust size
     getFillColor: [255, 140, 90, 200], // Red color for visibility
@@ -325,8 +326,9 @@ const MapComponent: React.FC = () => {
   });
   const cellsAboveLayer = new ScatterplotLayer({
     id: "point-layer",
-    data: aboveCells, // Point Data
-    getPosition: (d) => {
+    data: !grazingRange
+    ? aboveCells
+    : aboveCells.filter(d => d.grazing_range == grazingRange),    getPosition: (d) => {
       return d.vertices;
     },
     getRadius: 5000, // Adjust size
@@ -336,8 +338,9 @@ const MapComponent: React.FC = () => {
 
   const cellsNegativeLayer = new ScatterplotLayer({
     id: "point-layer",
-    data: negativeCells, // Point Data
-    getPosition: (d) => {
+    data: !grazingRange
+    ? negativeCells
+    : negativeCells.filter(d => d.grazing_range == grazingRange),    getPosition: (d) => {
       return d.vertices;
     },
     getRadius: 5000, // Adjust size
@@ -347,8 +350,9 @@ const MapComponent: React.FC = () => {
   });
   const cellsZeroLayer = new ScatterplotLayer({
     id: "point-layer",
-    data: zeroCells, // Point Data
-    getPosition: (d) => {
+    data: !grazingRange
+    ? zeroCells
+    : zeroCells.filter(d => d.grazing_range == grazingRange),    getPosition: (d) => {
       return d.vertices;
     },
     getRadius: 5000, // Adjust size
@@ -358,8 +362,9 @@ const MapComponent: React.FC = () => {
   });
   const cellsPositiveLayer = new ScatterplotLayer({
     id: "point-layer",
-    data: positiveCells, // Point Data
-    getPosition: (d) => d.vertices,
+    data: !grazingRange
+    ? positiveCells
+    : positiveCells.filter(d => d.grazing_range == grazingRange),    getPosition: (d) => d.vertices,
     getRadius: 5000, // Adjust size
     getFillColor: [0, 128, 128, 200], // Teal color
 
@@ -399,6 +404,7 @@ const MapComponent: React.FC = () => {
     showNegativeCells,
     showZeroCells,
     showPositiveCells,
+    grazingRange
   ]);
 
   if (!provinces || (provinces.length === 0 && !soums) || soums.length === 0) {

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -30,6 +30,7 @@ interface CellGeometry {
   name: string;
   coordinates: number[];
   vertices: [number, number][];
+  grazing: boolean; // Add grazing boolean value
 }
 
 const MAP_STYLE =
@@ -97,18 +98,23 @@ const MapComponent: React.FC = () => {
         json_below_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
+          grazing: feature.grazing, // Include grazing boolean value
         }))
       );
       setAtCapCells(
         json_at_cap_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
+          grazing: feature.grazing, // Include grazing boolean value
+
         }))
       );
       setAboveCells(
         json_above_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
+          grazing: feature.grazing, // Include grazing boolean value
+
         }))
       );
     } catch (error) {
@@ -140,18 +146,24 @@ const MapComponent: React.FC = () => {
         json_negative_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
+          grazing: feature.grazing, // Include grazing boolean value
+
         }))
       );
       setZeroCells(
         json_zero_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
+          grazing: feature.grazing, // Include grazing boolean value
+
         }))
       );
       setPositiveCells(
         json_positive_response.data.map((feature: any) => ({
           vertices: feature.wkb_geometry.coordinates,
           z_score: feature.z_score,
+          grazing: feature.grazing, // Include grazing boolean value
+
         }))
       );
     } catch (error) {

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -4,12 +4,13 @@
 import React, { useContext, useState, useEffect } from "react";
 import Button from "@/components/atoms/Button";
 import BarChart from "@/components/charts/barchart";
-import { Box, Drawer, Divider } from "@mui/material";
+import { Box, Drawer, Divider , Typography, Switch} from "@mui/material";
 import RadioButton from "@/components/atoms/RadioButton";
 import Slide from "@/components/molecules/Slide";
 import Toggle from "@/components/atoms/Toggle";
 import { LayerType, Context } from "../../utils/global";
 import SidePanelPercentageModal from "../molecules/SidePanelPercentageModal";
+import AgricultureIcon from '@mui/icons-material/Agriculture'; 
 
 interface SidePanelProps {
   yearOptions: string[];
@@ -271,20 +272,13 @@ const SidePanel: React.FC<SidePanelProps> = ({ yearOptions }) => {
                 onChange={handleYearSlider}
                 min={2011}
                 max={2022}
-                options={yearOptions}
-              />
-              <h2>Grazing Range</h2>
-              <Toggle
-                initialChecked={grazingRange ?? false}
-                onChange={(checked) => setGrazingRange(checked)}
-              />
-              <div>
+                options={yearOptions} />
+            <div>
                 <h2>Data Layers</h2>
                 <RadioButton
                   options={options}
                   selectedOption={selectedOption}
-                  onChange={handleOptionChange}
-                />
+                  onChange={handleOptionChange} />
               </div>
             </div>
           ) : (
@@ -331,7 +325,49 @@ const SidePanel: React.FC<SidePanelProps> = ({ yearOptions }) => {
             </div>
           )}
         </Box>
+        <Divider sx={{ my: 2 }} />
+        {/* Row with icon, heading, and switch */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            mb: 0.5 // small margin bottom before the text below
+          }}
+        >
+          <AgricultureIcon sx={{ mr: 1 }} />
+          <Typography
+            variant="h6"
+            component="h2"
+            sx={{ mr: 'auto' }} // pushes the switch to the right
+          >
+            Grazing Range
+          </Typography>
+          <Switch
+            checked={grazingRange ?? false}
+            onChange={(e) => setGrazingRange(e.target.checked)}
+            sx={{
+              // Override track color when on
+              '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+                backgroundColor: '#2E7D32', // dark green
+              },
+              // Override the thumb color when on
+              '& .MuiSwitch-switchBase.Mui-checked': {
+                color: '#ffffff', // white thumb
+              },
+            }}
+      
+             />
+        </Box>
+
+        {/* Descriptive text below */}
+        <Typography
+          variant="body2"
+          color="text.secondary"
+        >
+          View data only in land categorized as a grazing range.
+        </Typography>
       </Drawer>
+      
     </div>
   );
 };

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -4,13 +4,14 @@
 import React, { useContext, useState, useEffect } from "react";
 import Button from "@/components/atoms/Button";
 import BarChart from "@/components/charts/barchart";
-import { Box, Drawer, Divider , Typography, Switch} from "@mui/material";
+import { Box, Drawer, Divider , Typography, Switch, Chip} from "@mui/material";
 import RadioButton from "@/components/atoms/RadioButton";
 import Slide from "@/components/molecules/Slide";
 import Toggle from "@/components/atoms/Toggle";
 import { LayerType, Context } from "../../utils/global";
 import SidePanelPercentageModal from "../molecules/SidePanelPercentageModal";
 import AgricultureIcon from '@mui/icons-material/Agriculture'; 
+import CloseIcon from '@mui/icons-material/Close';
 
 interface SidePanelProps {
   yearOptions: string[];
@@ -188,21 +189,56 @@ const SidePanel: React.FC<SidePanelProps> = ({ yearOptions }) => {
       label: "Carrying Capacity",
       content: (
         <div style={{ display: "flex", gap: "10px" }}>
-          <Button
-            onClick={() => setShowBelowCells(!showBelowCells)}
-            label="Below"
-            sx={{ backgroundColor: showBelowCells ? "green" : "grey" }}
-          />
-          <Button
-            onClick={() => setShowAtCapCells(!showAtCapCells)}
-            label="At Capacity"
-            sx={{ backgroundColor: showAtCapCells ? "#C6BF31" : "grey" }}
-          />
-          <Button
-            onClick={() => setShowAboveCells(!showAboveCells)}
-            label="Above"
-            sx={{ backgroundColor: showAboveCells ? "red" : "grey" }}
-          />
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Chip
+              label="Below"
+              onClick={() => setShowBelowCells((prev) => !prev)}  
+              onDelete={showBelowCells ? () => setShowBelowCells(false) : undefined}  
+              deleteIcon={showBelowCells ? <CloseIcon /> : undefined}
+              sx={{
+                backgroundColor: showBelowCells ? 'green' : 'grey',
+                color: '#fff',
+                borderRadius: '16px',
+                fontWeight: 'bold',
+                // Make the close (delete) icon white
+                '.MuiChip-deleteIcon': {
+                  color: '#fff',
+                },
+              }}
+            />
+            <Chip
+              label="At Capacity"
+              onClick={() => setShowAtCapCells((prev) => !prev)}
+              onDelete={showAtCapCells ? () => setShowAtCapCells(false) : undefined}
+              deleteIcon={showAtCapCells ? <CloseIcon /> : undefined}
+              sx={{
+                backgroundColor: showAtCapCells ? '#C6BF31' : 'grey',
+                color: '#fff',
+                borderRadius: '16px',
+                fontWeight: 'bold',
+                // Make the close (delete) icon white
+                '.MuiChip-deleteIcon': {
+                  color: '#fff',
+                },
+              }}
+            />
+            <Chip
+              label="Above"
+              onClick={() => setShowAboveCells((prev) => !prev)}
+              onDelete={showAboveCells ? () => setShowAboveCells(false) : undefined}
+              deleteIcon={showAboveCells ? <CloseIcon /> : undefined}
+              sx={{
+                backgroundColor: showAboveCells ? 'red' : 'grey',
+                color: '#fff',
+                borderRadius: '16px',
+                fontWeight: 'bold',
+                // Make the close (delete) icon white
+                '.MuiChip-deleteIcon': {
+                  color: '#fff',
+                },
+              }}
+            />
+          </Box>
         </div>
       ),
     },
@@ -211,21 +247,50 @@ const SidePanel: React.FC<SidePanelProps> = ({ yearOptions }) => {
       label: "Z-Score",
       content: (
         <div style={{ display: "flex", gap: "10px" }}>
-          <Button
-            onClick={() => setShowPositiveCells(!showPositiveCells)}
-            label="Positive"
-            sx={{ backgroundColor: showPositiveCells ? "teal" : "grey" }}
-          />
-          <Button
-            onClick={() => setShowZeroCells(!showZeroCells)}
-            label="Zero"
-            sx={{ backgroundColor: showZeroCells ? "darkblue" : "grey" }}
-          />
-          <Button
-            onClick={() => setShowNegativeCells(!showNegativeCells)}
-            label="Negative"
-            sx={{ backgroundColor: showNegativeCells ? "purple" : "grey" }}
-          />
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Chip
+              label="Positive"
+              onClick={() => setShowPositiveCells(prev => !prev)}
+              onDelete={showPositiveCells ? () => setShowPositiveCells(false) : undefined}
+              deleteIcon={showPositiveCells ? <CloseIcon /> : undefined}
+              sx={{
+                backgroundColor: showPositiveCells ? 'teal' : 'grey',
+                color: '#fff',
+                fontWeight: 'bold',
+                '.MuiChip-deleteIcon': {
+                  color: '#fff',
+                },
+              }}
+            />
+            <Chip
+              label="Zero"
+              onClick={() => setShowZeroCells(prev => !prev)}
+              onDelete={showZeroCells ? () => setShowZeroCells(false) : undefined}
+              deleteIcon={showZeroCells ? <CloseIcon /> : undefined}
+              sx={{
+                backgroundColor: showZeroCells ? 'darkblue' : 'grey',
+                color: '#fff',
+                fontWeight: 'bold',
+                '.MuiChip-deleteIcon': {
+                  color: '#fff',
+                },
+              }}
+            />
+            <Chip
+              label="Negative"
+              onClick={() => setShowNegativeCells(prev => !prev)}
+              onDelete={showNegativeCells ? () => setShowNegativeCells(false) : undefined}
+              deleteIcon={showNegativeCells ? <CloseIcon /> : undefined}
+              sx={{
+                backgroundColor: showNegativeCells ? 'purple' : 'grey',
+                color: '#fff',
+                fontWeight: 'bold',
+                '.MuiChip-deleteIcon': {
+                  color: '#fff',
+                },
+              }}
+            />
+          </Box>
         </div>
       ),
     },

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -68,9 +68,6 @@ const MonitoringPlatform: React.FC = () => {
     setSelectedOption,
     displayName,
     setDisplayName,
-
-    isGrazingRangeSelected, // Pass to context
-    setIsGrazingRangeSelected,
   };
   console.log("In the map selecteProvince is " + selectedProvince);
   const yearOptions = Array.from({ length: 2014 - 2002 + 1 }, (_, index) =>

--- a/frontend/src/pages/monitoring-platform.tsx
+++ b/frontend/src/pages/monitoring-platform.tsx
@@ -28,6 +28,8 @@ const MonitoringPlatform: React.FC = () => {
   const [selectedOption, setSelectedOption] =
     useState<string>("carryingCapacity");
   const [displayName, setDisplayName] = useState<string>("");
+  const [isGrazingRangeSelected, setIsGrazingRangeSelected] = useState(false); // Define the variable
+
   const contextDict = {
     // Province & Selection
     selectedProvince,
@@ -66,6 +68,9 @@ const MonitoringPlatform: React.FC = () => {
     setSelectedOption,
     displayName,
     setDisplayName,
+
+    isGrazingRangeSelected, // Pass to context
+    setIsGrazingRangeSelected,
   };
   console.log("In the map selecteProvince is " + selectedProvince);
   const yearOptions = Array.from({ length: 2014 - 2002 + 1 }, (_, index) =>

--- a/frontend/src/utils/global.ts
+++ b/frontend/src/utils/global.ts
@@ -45,5 +45,8 @@ export type GlobalContext = {
 
   grazingRange: boolean | null;
   setGrazingRange: SetState<boolean>;
+
+  isGrazingRangeSelected: boolean | null; // Add isGrazingRangeSelected
+  setIsGrazingRangeSelected: SetState<boolean>;
 };
 export const Context = createContext<GlobalContext | undefined>(undefined);

--- a/frontend/src/utils/global.ts
+++ b/frontend/src/utils/global.ts
@@ -45,8 +45,5 @@ export type GlobalContext = {
 
   grazingRange: boolean | null;
   setGrazingRange: SetState<boolean>;
-
-  isGrazingRangeSelected: boolean | null; // Add isGrazingRangeSelected
-  setIsGrazingRangeSelected: SetState<boolean>;
 };
 export const Context = createContext<GlobalContext | undefined>(undefined);


### PR DESCRIPTION
## Overview

Implemented the grazing range filter that is set as a boolean and uses the random true and false data in the database to apply the filter on the carrying capacity and zscores. Frontend has been updated to look similar to the figma doc.

Files changed: 

frontend/src/components/Map.tsx
frontend/src/pages/monitoring-platform.tsx
frontend/src/utils/global.ts
frontend/src/components/organisms/SidePanel.tsx