### PR TITLE
ticket done

### DIFF
--- a/backend/src/controller/Cell.ts
+++ b/backend/src/controller/Cell.ts
@@ -216,3 +216,71 @@ export const getZScorePositive = async (
     }
   }
 };
+
+export const getCellValuesbyYearandCtype = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  if (supabase) {
+    try {
+      const { year, classificationType, lowerBound, upperBound } = req.params;
+
+      const selected_year = parseInt(year as string, 10);
+      const gte = parseFloat(lowerBound as string);
+      const lt = parseFloat(upperBound as string);
+
+      // Validate year 
+      if (isNaN(selected_year) || selected_year < 2011 || selected_year > 2022) {
+        res.status(400).json({
+          log: "Invalid year. Please provide a valid year.",
+        });
+        return;
+      }
+
+      // Validate classificationType
+      if (!["carrying_capacity", "z_score"].includes(classificationType)) {
+        res.status(400).json({
+          log: "Invalid classificationType. Use 'carrying_capacity' or 'z_score'.",
+        });
+        return;
+      }
+
+      // Validate lowerBound and upperBound
+      if (
+        isNaN(gte) ||
+        isNaN(lt) ||
+        gte < 0.0 ||
+        gte > 1.0 ||
+        lt < 0.0 ||
+        lt > 1.0 ||
+        gte >= lt
+      ) {
+        res.status(400).json({
+          log: "Invalid bounds. lowerBound must be less than upperBound and both must be between 0.0 and 1.0.",
+        });
+        return;
+      }
+
+      const { data, error } = await supabase.rpc("categorize_cells_by_year", {
+        selected_year: selected_year,
+        category_type: classificationType,
+        gte: gte,
+        lt: lt,
+      });
+
+      if (error) {
+        res.status(500).json({
+          log: "Error while collecting the data",
+          error: error.message,
+        });
+        return;
+      }
+
+      res
+        .status(201)
+        .json({ log: "Data was successfully Collected", data: data });
+    } catch (error: any) {
+      res.status(400).json({ message: error.message });
+    }
+  }
+};

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -41,6 +41,7 @@ import {
   getZScoreNegative,
   getZScoreZero,
   getZScorePositive,
+  getCellValuesbyYearandCtype,
 } from "./controller/Cell";
 
 const router = express.Router();
@@ -74,6 +75,8 @@ router.get("/cells/z_score_zero", getZScoreZero);
 router.get("/cells/z_score_positive", getZScorePositive);
 router.get("/:province_id/:category_type/cell-summary", getProvinceCellSummary);
 
+//
+router.get("/cells/:year/:classificationType/:lowerBound/:upperBound",getCellValuesbyYearandCtype)
 // Route to update a hexagon
 router.put("/hexagons/:hexagon_id", updateHexagon);
 

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -74,19 +74,19 @@ const MapComponent: React.FC = () => {
     showZeroCells,
     selectedLayerType,
     setSelectedLayerType,
-    grazingRange
+    grazingRange,
+    selectedYear
   } = context;
-
   const loadCarryingCapacityCells = async () => {
     try {
       const below_response = await fetch(
-        "http://localhost:8080/api//cells/bm_pred_below"
+        `http://localhost:8080/api/cells/${selectedYear}/carrying_capacity/0/0.4`
       );
       const at_cap_response = await fetch(
-        "http://localhost:8080/api//cells/bm_pred_at_cap"
+        `http://localhost:8080/api/cells/${selectedYear}/carrying_capacity/0.4/0.6`
       );
       const above_response = await fetch(
-        "http://localhost:8080/api//cells/bm_pred_above"
+        `http://localhost:8080/api/cells/${selectedYear}/carrying_capacity/0.6/1`
       );
 
       const [json_below_response, json_at_cap_response, json_above_response] =
@@ -123,15 +123,15 @@ const MapComponent: React.FC = () => {
   const loadZScoreCells = async () => {
     try {
       const negative_response = await fetch(
-        "http://localhost:8080/api/cells/z_score_negative"
+        `http://localhost:8080/api/cells/${selectedYear}/z_score/0/0.4`
       );
       const zero_response = await fetch(
-        "http://localhost:8080/api/cells/z_score_zero"
+        `http://localhost:8080/api/cells/${selectedYear}/z_score/0.4/0.6`
       );
       const positive_response = await fetch(
-        "http://localhost:8080/api/cells/z_score_positive"
+        `http://localhost:8080/api/cells/${selectedYear}/z_score/0.6/1`
       );
-
+      console.log(negative_response)
       const [
         json_negative_response,
         json_zero_response,
@@ -269,7 +269,7 @@ const MapComponent: React.FC = () => {
     loadCarryingCapacityCells();
     loadZScoreCells();
     // loadGrazingRangeCells();
-  }, []);
+  }, [selectedYear]);
 
   const provinceLayer = new PolygonLayer({
     id: "province-layer",
@@ -404,7 +404,8 @@ const MapComponent: React.FC = () => {
     showNegativeCells,
     showZeroCells,
     showPositiveCells,
-    grazingRange
+    grazingRange,
+    selectedYear
   ]);
 
   if (!provinces || (provinces.length === 0 && !soums) || soums.length === 0) {

--- a/frontend/src/components/organisms/SidePanel.tsx
+++ b/frontend/src/components/organisms/SidePanel.tsx
@@ -171,7 +171,6 @@ const SidePanel: React.FC<SidePanelProps> = ({ yearOptions }) => {
   const handleBack = () => {
     setProvinceData(null);
   };
-
   const handleOptionChange = (option: LayerType) => {
     setSelectedOption(option);
     setSelectedLayerType(option);


### PR DESCRIPTION
## Overview

In this ticket we implemented the year slider so the cells shown correspond to either their carrying capacity or z score for the specific year selected.

## Testing

We tested the backend by running the newly made route to see if different JSON outputs were returned for different year inputs, and the same when the year was the same. Then, for the frontend, we tested the slider by adjusting the year and seeing that the number of cells for the selected category(s) changed. 

## Impact
The year slider implementation would allow for the map to showcase data corresponding for a longer period of time instead of a random snapshot of data.

## Screenshots

1) Differences in cells displayed with one type of cell selected
Before
![image](https://github.com/user-attachments/assets/20ba7e51-ee66-4ddc-8840-7dd7d7400187)
After
![image](https://github.com/user-attachments/assets/0ad7fef7-e8fc-48a6-bcde-3b3f2d0b44c5)

2) Differences in cells displayed with multiple types of cells selected
Before
![image](https://github.com/user-attachments/assets/e6bb20f8-956e-4809-8a29-5655305996b5)
After
![image](https://github.com/user-attachments/assets/48db0012-adbb-4f98-9b5a-c2df24c0bc76)


