### PR TITLE
Fixed Year Slider Sensitivity

### DIFF
--- a/frontend/src/components/molecules/Slide.tsx
+++ b/frontend/src/components/molecules/Slide.tsx
@@ -17,20 +17,30 @@ const Slide: React.FC<SlideProps> = ({
   onChange,
   min,
   max,
-  options,
+  options = [],
 }) => {
-  const [value, setValue] = useState<number>(selectedValue || max);
+  const [sliderVal, setSliderVal] = useState<number>(selectedValue || max);
 
-  const handleSlideChange = (_: Event, newValue: number | number[]) => {
+  const handleSliderChange = (_: Event, newValue: number | number[]) => {
     if (typeof newValue === "number") {
-      setValue(newValue); // Update local state
-      onChange(newValue); // Call the onChange handler passed from parent
+      setSliderVal(newValue); // Update local state
+    }
+  };
+
+  // Handles when releasing the slider
+  const handleSliderCommit = (
+    _: React.SyntheticEvent | Event,
+    newValue: number | number[]
+  ) => {
+    if (typeof newValue === "number") {
+      setSliderVal(newValue); // Update local state
+      onChange(newValue); // Also notify parent component
     }
   };
 
   const handleDropdownChange = (newValue: number | null) => {
     if (newValue !== null) {
-      setValue(newValue);
+      setSliderVal(newValue);
       onChange(newValue);
     }
   };
@@ -75,21 +85,25 @@ const Slide: React.FC<SlideProps> = ({
               textAlign: "left",
               textDecoration: "none",
             }}
-          >
-            {<Dropdown
-        options={options}
-        value={value.toString()}
-        onChange={handleDropdownChange}
-        sx={{ width: "64px", alignItems: 'center' }}
-        disableClearable={true}/>}
-          </span>
+          ></span>{" "}
+          {
+            <Dropdown
+              options={options}
+              value={sliderVal.toString()}
+              onChange={(newVal) => handleDropdownChange(Number(newVal))}
+              sx={{ width: "64px", alignItems: "center" }}
+              label={""}
+            />
+          }
         </Box>
       </Box>
       <Slider
-        value={value}
+        id="myRange"
+        value={sliderVal}
         min={min}
         max={max}
-        onChange={handleSlideChange}
+        onChange={handleSliderChange} // Call when dragging slider
+        onChangeCommitted={handleSliderCommit} //Call once finished dragging slider
         valueLabelDisplay="auto"
       />
       <Box display="flex" width="100%" justifyContent="space-between" mt={2}>


### PR DESCRIPTION

## Overview

<!-- Summarize the goal of the ticket and the changes you made to reach that goal -->
The goal of this ticket was to implement callback functions for the year slider to address issues with sensitivity when dragging the slider. I approached this issue by adding another callback function on top of the existing handleSliderChange and handleDropdownChange, called handleSliderCommit. I edited the code where handleSliderChange no longer notifies the parent every time the slider is dragged, but instead the parent is now only notified when the handleSliderCommit is called which happens when the user releases the dragging motion. 

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include reproduction steps and/or how to turn the feature on if applicable. -->
I tested this feature by running the local host and viewing the slider functionality.

## Impact

<!-- In 1-2 sentences describe how you think your PR will contribute to the project repo and the overall goal of the GreenZone project (check PRD for details of GreenZone's Mission) -->
I believe that this new functionality can help improve user experience when trying to navigate the website and choosing a specific year to view in detail.

## Screenshots

<!-- GreenZone is a very visual heavy project, so please include screenshots of your changes, if this was a frontend assignment.  -->
![image](https://github.com/user-attachments/assets/a2dd0a29-1295-4fff-a855-9dd9c9313f89)

You can now drag the slider without it immediately popping up the land area information page (it only appears after the user releases their mouse)

## Notes

<!-- Any issues/suggestions relating to the ticket, git repo, partner assignment, TL duties please mention here!  -->
